### PR TITLE
Add KPI dropdown to insights tool

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -28,6 +28,7 @@ app.add_middleware(
 class InsightsRequest(BaseModel):
     topic: str
     advertiser: str
+    kpi: str
     include_google_trends: bool = True
 
 
@@ -39,6 +40,7 @@ def create_insights(req: InsightsRequest):
         result = generate_insights(
             topic=req.topic,
             advertiser=req.advertiser,
+            kpi=req.kpi,
             include_google_trends=req.include_google_trends,
         )
         return result

--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -51,12 +51,15 @@ function SkeletonCard() {
 export default function InsightsTool() {
   const [topic, setTopic] = useState("");
   const [advertiser, setAdvertiser] = useState("");
+  const [kpi, setKpi] = useState("");
   const [includeTrends, setIncludeTrends] = useState(true);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<InsightsResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const canGenerate = topic.trim() !== "" && advertiser.trim() !== "";
+  const KPI_OPTIONS = ["Awareness", "Consideration", "Viewability", "Clicks"];
+
+  const canGenerate = topic.trim() !== "" && advertiser.trim() !== "" && kpi !== "";
 
   async function handleGenerate() {
     setLoading(true);
@@ -70,6 +73,7 @@ export default function InsightsTool() {
         body: JSON.stringify({
           topic: topic.trim(),
           advertiser: advertiser.trim(),
+          kpi,
           include_google_trends: includeTrends,
         }),
       });
@@ -107,7 +111,7 @@ export default function InsightsTool() {
 
           {/* Input panel */}
           <GlassCard className="mb-8">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
               <div>
                 <label className="text-[10px] font-bold tracking-widest text-on-surface-variant uppercase mb-2 block">
                   Topic
@@ -131,6 +135,21 @@ export default function InsightsTool() {
                   placeholder="e.g. Yakult, The Ordinary, Patagonia"
                   className="w-full bg-surface-container-lowest border border-outline-variant rounded-xl px-4 py-3 text-on-surface placeholder-slate-500 focus:outline-none focus:border-accent-cyan focus:shadow-[0_0_0_1px_rgba(31,137,223,0.3)] transition-all"
                 />
+              </div>
+              <div>
+                <label className="text-[10px] font-bold tracking-widest text-on-surface-variant uppercase mb-2 block">
+                  KPI
+                </label>
+                <select
+                  value={kpi}
+                  onChange={(e) => setKpi(e.target.value)}
+                  className="w-full bg-surface-container-lowest border border-outline-variant rounded-xl px-4 py-3 text-on-surface focus:outline-none focus:border-accent-cyan focus:shadow-[0_0_0_1px_rgba(31,137,223,0.3)] transition-all"
+                >
+                  <option value="" disabled>Select a KPI</option>
+                  {KPI_OPTIONS.map((option) => (
+                    <option key={option} value={option}>{option}</option>
+                  ))}
+                </select>
               </div>
             </div>
 

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -24,7 +24,9 @@ How the advertiser's stated goals, challenges, and recent activity connect to th
 When and how to reach the target audience based on engagement data. Cite specific data points from the audience timing data (peak months, best days, top segments, index values).
 
 ## Messaging & Tone Recommendations
-Specific recommendations for campaign messaging, tone, and creative direction. For each recommendation:
+Specific recommendations for campaign messaging, tone, and creative direction. Tailor all recommendations to support the advertiser's stated KPI. For each recommendation, explain how it serves that specific KPI objective.
+
+For each recommendation:
 - Tie it to specific evidence from the data (editorial quotes, audience data points, trend signals, or brand research findings)
 - Explain how it aligns with the advertiser's known strategy, campaigns, or brand values from the research
 - Where the research includes source links, include them as references so the reader can verify the evidence
@@ -35,6 +37,7 @@ USER_PROMPT_TEMPLATE = """Generate a strategic insights brief for the following:
 
 **Topic:** {topic}
 **Advertiser:** {advertiser}
+**KPI:** {advertiser_kpi}
 
 ---
 

--- a/src/synthesiser.py
+++ b/src/synthesiser.py
@@ -44,6 +44,7 @@ def _format_advertiser_research(skill_results: list[dict]) -> str:
 def generate_insights(
     topic: str,
     advertiser: str,
+    kpi: str,
     include_google_trends: bool = True,
 ) -> dict:
     """Main pipeline: gather data from all sources, synthesise with GPT-4o.
@@ -74,6 +75,7 @@ def generate_insights(
     user_prompt = USER_PROMPT_TEMPLATE.format(
         topic=topic,
         advertiser=advertiser,
+        advertiser_kpi=kpi,
         editorial_insights=editorial_insights,
         advertiser_research=advertiser_research,
         audience_timing=audience_timing,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -79,6 +79,7 @@ def test_insights_returns_200_with_valid_payload():
             json={
                 "topic": "sustainable fashion",
                 "advertiser": "EcoWear",
+                "kpi": "Consideration",
                 "include_google_trends": True,
             },
         )
@@ -96,6 +97,7 @@ def test_insights_response_body_matches_generate_insights_return_value():
             json={
                 "topic": "sustainable fashion",
                 "advertiser": "EcoWear",
+                "kpi": "Clicks",
                 "include_google_trends": True,
             },
         )
@@ -103,7 +105,7 @@ def test_insights_response_body_matches_generate_insights_return_value():
 
 
 def test_insights_passes_correct_arguments_to_generate_insights():
-    """POST /api/insights forwards topic, advertiser, and include_google_trends to generate_insights."""
+    """POST /api/insights forwards topic, advertiser, kpi, and include_google_trends to generate_insights."""
     client = TestClient(app)
     with patch("api.main.config") as mock_config, \
          patch("api.main.generate_insights", return_value=MOCK_INSIGHTS_RESULT) as mock_gen:
@@ -113,12 +115,14 @@ def test_insights_passes_correct_arguments_to_generate_insights():
             json={
                 "topic": "gut health",
                 "advertiser": "NutriCo",
+                "kpi": "Awareness",
                 "include_google_trends": False,
             },
         )
     mock_gen.assert_called_once_with(
         topic="gut health",
         advertiser="NutriCo",
+        kpi="Awareness",
         include_google_trends=False,
     )
 
@@ -131,11 +135,12 @@ def test_insights_include_google_trends_defaults_to_true():
         mock_config.OPENAI_API_KEY = "sk-test-key"
         client.post(
             "/api/insights",
-            json={"topic": "travel", "advertiser": "Airwaves"},
+            json={"topic": "travel", "advertiser": "Airwaves", "kpi": "Viewability"},
         )
     mock_gen.assert_called_once_with(
         topic="travel",
         advertiser="Airwaves",
+        kpi="Viewability",
         include_google_trends=True,
     )
 
@@ -153,7 +158,7 @@ def test_insights_returns_500_when_api_key_is_empty_string():
         mock_config.OPENAI_API_KEY = ""
         response = client.post(
             "/api/insights",
-            json={"topic": "travel", "advertiser": "Airwaves"},
+            json={"topic": "travel", "advertiser": "Airwaves", "kpi": "Clicks"},
         )
     assert response.status_code == 500
 
@@ -166,7 +171,7 @@ def test_insights_error_detail_mentions_api_key_when_missing():
         mock_config.OPENAI_API_KEY = ""
         response = client.post(
             "/api/insights",
-            json={"topic": "travel", "advertiser": "Airwaves"},
+            json={"topic": "travel", "advertiser": "Airwaves", "kpi": "Clicks"},
         )
     assert "OPENAI_API_KEY" in response.json()["detail"]
 
@@ -184,7 +189,7 @@ def test_insights_returns_500_when_generate_insights_raises():
         mock_config.OPENAI_API_KEY = "sk-test-key"
         response = client.post(
             "/api/insights",
-            json={"topic": "skincare", "advertiser": "GlowCo"},
+            json={"topic": "skincare", "advertiser": "GlowCo", "kpi": "Awareness"},
         )
     assert response.status_code == 500
 
@@ -197,7 +202,7 @@ def test_insights_error_detail_contains_exception_message():
         mock_config.OPENAI_API_KEY = "sk-test-key"
         response = client.post(
             "/api/insights",
-            json={"topic": "skincare", "advertiser": "GlowCo"},
+            json={"topic": "skincare", "advertiser": "GlowCo", "kpi": "Awareness"},
         )
     assert "ChromaDB unavailable" in response.json()["detail"]
 
@@ -210,7 +215,7 @@ def test_insights_returns_500_when_generate_insights_raises_value_error():
         mock_config.OPENAI_API_KEY = "sk-test-key"
         response = client.post(
             "/api/insights",
-            json={"topic": "skincare", "advertiser": "GlowCo"},
+            json={"topic": "skincare", "advertiser": "GlowCo", "kpi": "Awareness"},
         )
     assert response.status_code == 500
 
@@ -225,7 +230,7 @@ def test_insights_returns_422_when_topic_is_missing():
     client = TestClient(app)
     response = client.post(
         "/api/insights",
-        json={"advertiser": "BrandX"},
+        json={"advertiser": "BrandX", "kpi": "Clicks"},
     )
     assert response.status_code == 422
 
@@ -235,7 +240,17 @@ def test_insights_returns_422_when_advertiser_is_missing():
     client = TestClient(app)
     response = client.post(
         "/api/insights",
-        json={"topic": "wellness"},
+        json={"topic": "wellness", "kpi": "Clicks"},
+    )
+    assert response.status_code == 422
+
+
+def test_insights_returns_422_when_kpi_is_missing():
+    """POST /api/insights returns 422 when required field `kpi` is absent."""
+    client = TestClient(app)
+    response = client.post(
+        "/api/insights",
+        json={"topic": "wellness", "advertiser": "BrandX"},
     )
     assert response.status_code == 422
 

--- a/tests/test_synthesiser.py
+++ b/tests/test_synthesiser.py
@@ -12,6 +12,14 @@ def test_system_prompt_has_key_sections():
     assert "Editorial Insights" in SYSTEM_PROMPT
 
 
+def test_system_prompt_messaging_section_references_kpi():
+    """The Messaging & Tone section should instruct the model to tailor recommendations to the KPI."""
+    # Find the Messaging & Tone section and check it mentions KPI
+    messaging_start = SYSTEM_PROMPT.index("Messaging & Tone")
+    messaging_section = SYSTEM_PROMPT[messaging_start:]
+    assert "KPI" in messaging_section
+
+
 def test_user_prompt_template_has_placeholders():
     assert "{topic}" in USER_PROMPT_TEMPLATE
     assert "{advertiser}" in USER_PROMPT_TEMPLATE
@@ -19,12 +27,14 @@ def test_user_prompt_template_has_placeholders():
     assert "{advertiser_research}" in USER_PROMPT_TEMPLATE
     assert "{audience_timing}" in USER_PROMPT_TEMPLATE
     assert "{google_trends}" in USER_PROMPT_TEMPLATE
+    assert "{advertiser_kpi}" in USER_PROMPT_TEMPLATE
 
 
 def test_user_prompt_renders():
     rendered = USER_PROMPT_TEMPLATE.format(
         topic="test topic",
         advertiser="test brand",
+        advertiser_kpi="Awareness",
         editorial_insights="some insights",
         advertiser_research="some research",
         audience_timing="some timing",
@@ -32,6 +42,35 @@ def test_user_prompt_renders():
     )
     assert "test topic" in rendered
     assert "test brand" in rendered
+    assert "Awareness" in rendered
+
+
+def test_generate_insights_accepts_kpi_and_injects_into_prompt():
+    """generate_insights() should accept a kpi parameter and include it in the prompt sent to GPT-4o."""
+    from unittest.mock import patch, MagicMock
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Test brief content"
+
+    with patch("src.synthesiser.search_transcripts") as mock_search, \
+         patch("src.synthesiser.research_advertiser", return_value=[]), \
+         patch("src.synthesiser.load_audience_data") as mock_load, \
+         patch("src.synthesiser.get_topic_trends", return_value="No data"), \
+         patch("src.synthesiser.OpenAI") as mock_openai_cls:
+
+        mock_search.return_value = {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+        mock_load.return_value = MagicMock()
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_cls.return_value = mock_client
+
+        from src.synthesiser import generate_insights
+        generate_insights(topic="test", advertiser="TestCo", kpi="Clicks", include_google_trends=False)
+
+        call_args = mock_client.chat.completions.create.call_args
+        user_prompt = call_args[1]["messages"][1]["content"]
+        assert "Clicks" in user_prompt
 
 
 def test_format_editorial_insights_empty():


### PR DESCRIPTION
## Summary

- Adds a required KPI dropdown (Awareness, Consideration, Viewability, Clicks) to the insights tool input panel
- Threads the KPI value through the API, synthesiser, and into the LLM prompt
- Tailors the Messaging & Tone Recommendations section to the selected campaign objective
- All other brief sections remain unaffected

Closes #2, closes #3
Parent PRD: #1

## Test plan

- [x] `USER_PROMPT_TEMPLATE` contains `{advertiser_kpi}` placeholder
- [x] `SYSTEM_PROMPT` Messaging & Tone section references KPI
- [x] `generate_insights()` accepts and injects `kpi` into prompt
- [x] API forwards `kpi` to `generate_insights()`
- [x] API returns 422 when `kpi` is missing
- [x] All 41 tests passing
- [x] TypeScript compiles cleanly
- [x] Manual test: select each KPI option and verify brief output reflects the objective

🤖 Generated with [Claude Code](https://claude.com/claude-code)