### PR TITLE
Add ad format recommendations as fifth data source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 build/
 .streamlit/
 .DS_Store
+data/format_recommendations.csv

--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -35,6 +35,7 @@ interface InsightsResult {
   research_skills: SkillResult[];
   audience_timing: string;
   google_trends: string;
+  format_recommendations: string;
 }
 
 function SkeletonCard() {
@@ -349,6 +350,15 @@ export default function InsightsTool() {
                 <CollapsiblePanel title="Google Trends" defaultOpen={false}>
                   <p className="text-on-surface-variant text-sm leading-relaxed whitespace-pre-wrap">
                     {result.google_trends}
+                  </p>
+                </CollapsiblePanel>
+              )}
+
+              {/* Format Recommendations panel */}
+              {result.format_recommendations && (
+                <CollapsiblePanel title="Format Recommendations" defaultOpen={false}>
+                  <p className="text-on-surface-variant text-sm leading-relaxed whitespace-pre-wrap">
+                    {result.format_recommendations}
                   </p>
                 </CollapsiblePanel>
               )}

--- a/src/formats.py
+++ b/src/formats.py
@@ -1,0 +1,47 @@
+import csv
+import os
+
+DEFAULT_CSV_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "format_recommendations.csv")
+
+DISPLAY_COLUMNS = [
+    "Format", "format_family", "CTR avg", "Viewability", "Indicative cost",
+    "primary_objective", "secondary_objective", "best_for_brief",
+    "best_for_advertiser_type", "When to use this",
+]
+
+
+def load_format_data(csv_path=None):
+    # type: (str) -> str
+    """Load format recommendations CSV and return a prompt-ready string.
+
+    Returns a fallback message if the file is missing.
+    """
+    if csv_path is None:
+        csv_path = DEFAULT_CSV_PATH
+
+    if not os.path.exists(csv_path):
+        return "No format recommendation data available."
+
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    if not rows:
+        return "No format recommendation data available."
+
+    parts = []
+    for row in rows:
+        lines = []
+        lines.append(row.get("Format", "Unknown Format"))
+        lines.append("  Family: %s" % row.get("format_family", "N/A"))
+        lines.append("  CTR avg: %s" % row.get("CTR avg", "N/A"))
+        lines.append("  Viewability: %s" % row.get("Viewability", "N/A"))
+        lines.append("  Indicative cost: %s" % row.get("Indicative cost", "N/A"))
+        lines.append("  Primary objective: %s" % row.get("primary_objective", "N/A"))
+        lines.append("  Secondary objective: %s" % row.get("secondary_objective", "N/A"))
+        lines.append("  Best for brief: %s" % row.get("best_for_brief", "N/A"))
+        lines.append("  Best for advertiser type: %s" % row.get("best_for_advertiser_type", "N/A"))
+        lines.append("  When to use: %s" % row.get("When to use this", "N/A"))
+        parts.append("\n".join(lines))
+
+    return "\n\n".join(parts)

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -26,6 +26,20 @@ How the advertiser's stated goals, challenges, and recent activity connect to th
 ## Audience Timing
 When and how to reach the target audience based on engagement data. Cite specific data points from the audience timing data (peak months, best days, top segments, index values).
 
+## Recommended Products
+Based on the format recommendation data provided, recommend 3-5 specific ad formats that best align with the advertiser's KPI and brief context. For each recommended format:
+- State the format name with its key metrics (CTR average, viewability, indicative cost)
+- Incorporate the format's usage guidance naturally (e.g. "this product is great for efficient reach, simple messaging...")
+- Explain why this format fits the specific brief — connect it to the KPI, the advertiser's goals, or the editorial themes
+
+Use this KPI-to-objective mapping when selecting formats:
+- Awareness → prioritise formats with Awareness or Reach as primary objective
+- Consideration → prioritise formats with Consideration as primary objective
+- Viewability → prioritise formats with the highest viewability scores regardless of stated objective
+- Clicks → prioritise formats with the highest CTR and Direct response as primary objective
+
+If no format recommendation data is available, note this explicitly.
+
 ## Messaging & Tone Recommendations
 Specific recommendations for campaign messaging, tone, and creative direction. Tailor all recommendations to support the advertiser's stated KPI. For each recommendation, explain how it serves that specific KPI objective.
 
@@ -65,6 +79,13 @@ The following research was gathered from multiple angles on the advertiser. Use 
 
 ### Google Trends
 {google_trends}
+
+---
+
+### Format Recommendations
+The following is the full catalogue of available ad formats with performance benchmarks. Use this to build the Recommended Products section.
+
+{format_recommendations}
 
 ---
 

--- a/src/synthesiser.py
+++ b/src/synthesiser.py
@@ -4,6 +4,7 @@ from src.vectorstore import search_transcripts
 from src.web_search import research_advertiser
 from src.audience import load_audience_data, get_topic_trends
 from src.trends import get_trend_data
+from src.formats import load_format_data
 from src.prompts import SYSTEM_PROMPT, USER_PROMPT_TEMPLATE
 
 
@@ -71,7 +72,10 @@ def generate_insights(
     else:
         google_trends = "Google Trends data not requested."
 
-    # 5. Assemble prompt
+    # 5. Load format recommendations
+    format_recommendations = load_format_data()
+
+    # 6. Assemble prompt
     user_prompt = USER_PROMPT_TEMPLATE.format(
         topic=topic,
         advertiser=advertiser,
@@ -80,9 +84,10 @@ def generate_insights(
         advertiser_research=advertiser_research,
         audience_timing=audience_timing,
         google_trends=google_trends,
+        format_recommendations=format_recommendations,
     )
 
-    # 6. Call GPT-4o
+    # 7. Call GPT-4o
     client = OpenAI(api_key=config.OPENAI_API_KEY)
     response = client.chat.completions.create(
         model=config.CHAT_MODEL,
@@ -102,4 +107,5 @@ def generate_insights(
         "research_skills": skill_results,
         "audience_timing": audience_timing,
         "google_trends": google_trends,
+        "format_recommendations": format_recommendations,
     }

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,0 +1,62 @@
+import os
+import tempfile
+import csv
+
+from src.formats import load_format_data
+
+
+def _create_test_csv(path):
+    """Create a minimal CSV with the expected columns."""
+    rows = [
+        {
+            "Format": "Standard display - Mobile Banner",
+            "format_family": "Standard display",
+            "CTR avg": "0.08%",
+            "Viewability": "72.49%",
+            "Indicative cost": "Low",
+            "primary_objective": "Reach",
+            "secondary_objective": "Awareness",
+            "best_for_brief": "Mobile-heavy campaigns needing efficient reach",
+            "best_for_advertiser_type": "Performance-led or budget-conscious advertisers",
+            "When to use this": "Use for efficient reach, simple messaging, and campaigns where broad coverage matters.",
+        },
+        {
+            "Format": "Infinity skin - core",
+            "format_family": "Infinity desktop",
+            "CTR avg": "2.21%",
+            "Viewability": "85.82%",
+            "Indicative cost": "High",
+            "primary_objective": "Awareness",
+            "secondary_objective": "Consideration",
+            "best_for_brief": "Premium desktop storytelling",
+            "best_for_advertiser_type": "Premium brands, launches",
+            "When to use this": "Use when the advertiser wants a premium, immersive desktop execution.",
+        },
+    ]
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_load_format_data_returns_format_names_and_metrics():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "format_recommendations.csv")
+        _create_test_csv(csv_path)
+
+        result = load_format_data(csv_path)
+
+        assert "Standard display - Mobile Banner" in result
+        assert "Infinity skin - core" in result
+        assert "0.08%" in result
+        assert "2.21%" in result
+        assert "72.49%" in result
+        assert "85.82%" in result
+        assert "Low" in result
+        assert "High" in result
+
+
+def test_load_format_data_missing_csv_returns_fallback():
+    result = load_format_data("/nonexistent/path/format_recommendations.csv")
+
+    assert "No format recommendation data available" in result

--- a/tests/test_synthesiser.py
+++ b/tests/test_synthesiser.py
@@ -33,6 +33,29 @@ def test_system_prompt_key_recommendations_instructs_concise_numbered_list():
     assert "number" in recs_section.lower()
 
 
+def test_system_prompt_has_recommended_products_section():
+    """SYSTEM_PROMPT should contain a Recommended Products output section."""
+    assert "Recommended Products" in SYSTEM_PROMPT
+
+
+def test_system_prompt_recommended_products_position():
+    """Recommended Products should appear after Audience Timing and before Messaging & Tone."""
+    recs_pos = SYSTEM_PROMPT.index("Recommended Products")
+    audience_pos = SYSTEM_PROMPT.index("Audience Timing")
+    messaging_pos = SYSTEM_PROMPT.index("Messaging & Tone")
+    assert audience_pos < recs_pos < messaging_pos
+
+
+def test_system_prompt_recommended_products_has_kpi_mapping():
+    """Recommended Products section should contain KPI-to-objective mapping."""
+    recs_start = SYSTEM_PROMPT.index("Recommended Products")
+    messaging_start = SYSTEM_PROMPT.index("Messaging & Tone")
+    recs_section = SYSTEM_PROMPT[recs_start:messaging_start]
+    assert "Awareness" in recs_section
+    assert "Clicks" in recs_section or "CTR" in recs_section
+    assert "Viewability" in recs_section
+
+
 def test_system_prompt_messaging_section_references_kpi():
     """The Messaging & Tone section should instruct the model to tailor recommendations to the KPI."""
     # Find the Messaging & Tone section and check it mentions KPI
@@ -49,6 +72,7 @@ def test_user_prompt_template_has_placeholders():
     assert "{audience_timing}" in USER_PROMPT_TEMPLATE
     assert "{google_trends}" in USER_PROMPT_TEMPLATE
     assert "{advertiser_kpi}" in USER_PROMPT_TEMPLATE
+    assert "{format_recommendations}" in USER_PROMPT_TEMPLATE
 
 
 def test_user_prompt_renders():
@@ -60,6 +84,7 @@ def test_user_prompt_renders():
         advertiser_research="some research",
         audience_timing="some timing",
         google_trends="some trends",
+        format_recommendations="some formats",
     )
     assert "test topic" in rendered
     assert "test brand" in rendered


### PR DESCRIPTION
## Summary
- New `src/formats.py` module loads a CSV catalogue of 19 ad formats and formats it for the prompt and frontend display
- `SYSTEM_PROMPT` gains a "Recommended Products" section (between Audience Timing and Messaging & Tone) with explicit KPI-to-objective mapping instructing GPT-4o to select 3-5 formats with metrics and justification
- `USER_PROMPT_TEMPLATE` gains a `{format_recommendations}` placeholder with the full format catalogue
- Pipeline in `synthesiser.py` wired to load format data and return it in the API response
- Frontend adds a "Format Recommendations" collapsible panel for raw data inspection
- CSV is gitignored to keep proprietary performance benchmarks out of the public repo
- 5 new tests (2 loader, 3 prompt), all 49 tests pass

Closes #11, closes #12
Parent PRD: #10

## Test plan
- [x] `python3 -m pytest tests/ -v` — 49/49 pass
- [x] Frontend builds clean (`npx next build`)
- [ ] Manual: generate an insight and verify "Recommended Products" section appears in the brief
- [ ] Manual: verify Format Recommendations collapsible panel shows raw format data
- [ ] Manual: verify brief still generates correctly if CSV is deleted (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)