### PR TITLE
Add At a Glance summary dashboard

### DIFF
--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -107,6 +107,59 @@ const markdownComponents = {
   ),
 };
 
+const GLANCE_ICONS: Record<string, React.ReactNode> = {
+  "Core Products": (
+    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15.75 10.5V6a3.75 3.75 0 10-7.5 0v4.5m11.356-1.993l1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 01-1.12-1.243l1.264-12A1.125 1.125 0 015.513 7.5h12.974c.576 0 1.059.435 1.119 1.007zM8.625 10.5a.375.375 0 11-.75 0 .375.375 0 01.75 0zm7.5 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
+    </svg>
+  ),
+  "Latest News": (
+    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 01-2.25 2.25M16.5 7.5V18a2.25 2.25 0 002.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 002.25 2.25h13.5M6 7.5h3v3H6v-3z" />
+    </svg>
+  ),
+  "Messaging": (
+    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 110-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 01-1.44-4.282m3.102.069a18.03 18.03 0 01-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 018.835 2.535M10.34 6.66a23.847 23.847 0 008.835-2.535m0 0A23.74 23.74 0 0018.795 3m.38 1.125a23.91 23.91 0 011.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 001.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 010 3.46" />
+    </svg>
+  ),
+  "Tone": (
+    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.53 16.122a3 3 0 00-5.78 1.128 2.25 2.25 0 01-2.4 2.245 4.5 4.5 0 008.4-2.245c0-.399-.078-.78-.22-1.128zm0 0a15.998 15.998 0 003.388-1.62m-5.043-.025a15.994 15.994 0 011.622-3.395m3.42 3.42a15.995 15.995 0 004.764-4.648l3.876-5.814a1.151 1.151 0 00-1.597-1.597L14.146 6.32a15.996 15.996 0 00-4.649 4.763m3.42 3.42a6.776 6.776 0 00-3.42-3.42" />
+    </svg>
+  ),
+  "Editor Voice": (
+    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
+    </svg>
+  ),
+  "Top Format": (
+    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+    </svg>
+  ),
+};
+
+interface GlanceCard {
+  label: string;
+  content: string;
+}
+
+function parseGlanceCards(sectionContent: string): GlanceCard[] {
+  return sectionContent
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.includes(":"))
+    .map((line) => {
+      const colonIndex = line.indexOf(":");
+      return {
+        label: line.slice(0, colonIndex).trim(),
+        content: line.slice(colonIndex + 1).trim(),
+      };
+    })
+    .filter((card) => card.label && card.content);
+}
+
 export default function InsightsTool() {
   const [topic, setTopic] = useState("");
   const [advertiser, setAdvertiser] = useState("");
@@ -256,11 +309,44 @@ export default function InsightsTool() {
           {/* Results */}
           {result && !loading && (() => {
             const sections = parseSections(result.content);
+            const atAGlance = sections.find((s) => s.title === "At a Glance");
             const keyRecs = sections.find((s) => s.title === "Key Recommendations");
-            const detailSections = sections.filter((s) => s.title !== "Key Recommendations");
+            const detailSections = sections.filter(
+              (s) => s.title !== "Key Recommendations" && s.title !== "At a Glance"
+            );
+            const glanceCards = atAGlance ? parseGlanceCards(atAGlance.content) : [];
 
             return (
             <div className="space-y-6">
+              {/* At a Glance dashboard */}
+              {glanceCards.length > 0 && (
+                <GlassCard>
+                  <div className="mb-4">
+                    <StatusDot label="At a Glance" />
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    {glanceCards.map((card, i) => (
+                      <div
+                        key={i}
+                        className="bg-surface-container-lowest rounded-xl p-4 border border-white/5 flex items-start gap-3"
+                      >
+                        <div className="shrink-0 mt-0.5">
+                          {GLANCE_ICONS[card.label] || GLANCE_ICONS["Core Products"]}
+                        </div>
+                        <div>
+                          <p className="text-[10px] font-bold tracking-widest text-on-surface-variant uppercase mb-1">
+                            {card.label}
+                          </p>
+                          <p className="text-on-surface text-sm leading-relaxed">
+                            {card.content}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </GlassCard>
+              )}
+
               {/* Executive summary banner */}
               {keyRecs && keyRecs.content && (
                 <div className="glass-card rounded-2xl p-6 border border-white/10 shadow-2xl border-l-4 border-l-accent-cyan">

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -4,6 +4,16 @@ Your output should be structured, evidence-based, and commercially focused. Writ
 
 Structure your response with these sections:
 
+## At a Glance
+Produce exactly 6 one-line summaries using the fixed labels below. Each line must follow the format `Label: Content` — one per line, no bullets, no numbering. Keep each to a single concise sentence.
+
+Core Products: [what the advertiser sells — their key products or services]
+Latest News: [one recent development, campaign, or announcement]
+Messaging: [one-line recommended messaging direction]
+Tone: [one-line recommended creative tone]
+Editor Voice: [one standout quote or insight from the editorial data]
+Top Format: [the single best ad format recommendation with key metric]
+
 ## Key Recommendations
 Start with 3-5 concise, actionable one-line recommendations. Each should be a single sentence that a commercial strategist can immediately act on. Number them. Do not elaborate here — the detail comes in later sections.
 

--- a/tests/test_synthesiser.py
+++ b/tests/test_synthesiser.py
@@ -33,6 +33,31 @@ def test_system_prompt_key_recommendations_instructs_concise_numbered_list():
     assert "number" in recs_section.lower()
 
 
+def test_system_prompt_has_at_a_glance_section():
+    """SYSTEM_PROMPT should contain an At a Glance output section."""
+    assert "At a Glance" in SYSTEM_PROMPT
+
+
+def test_system_prompt_at_a_glance_is_before_key_recommendations():
+    """At a Glance should appear before Key Recommendations in SYSTEM_PROMPT."""
+    glance_pos = SYSTEM_PROMPT.index("At a Glance")
+    recs_pos = SYSTEM_PROMPT.index("Key Recommendations")
+    assert glance_pos < recs_pos
+
+
+def test_system_prompt_at_a_glance_has_fixed_labels():
+    """At a Glance section should reference all 6 fixed labels."""
+    glance_start = SYSTEM_PROMPT.index("At a Glance")
+    key_recs_start = SYSTEM_PROMPT.index("Key Recommendations")
+    glance_section = SYSTEM_PROMPT[glance_start:key_recs_start]
+    assert "Core Products" in glance_section
+    assert "Latest News" in glance_section
+    assert "Messaging" in glance_section
+    assert "Tone" in glance_section
+    assert "Editor Voice" in glance_section
+    assert "Top Format" in glance_section
+
+
 def test_system_prompt_has_recommended_products_section():
     """SYSTEM_PROMPT should contain a Recommended Products output section."""
     assert "Recommended Products" in SYSTEM_PROMPT


### PR DESCRIPTION
## Summary
- SYSTEM_PROMPT gains `## At a Glance` as the first output section, instructing GPT-4o to produce 6 labelled one-liners (Core Products, Latest News, Messaging, Tone, Editor Voice, Top Format)
- Frontend parses the section, maps each label to an inline SVG icon in accent-cyan, and renders a 3x2 grid of flat cards inside a parent GlassCard — positioned above Key Recommendations
- 3 new prompt tests, all 52 tests pass, frontend builds clean

Closes #15
Parent PRD: #14

## Test plan
- [x] `python3 -m pytest tests/ -v` — 52/52 pass
- [x] Frontend builds clean (`npx next build`)
- [ ] Manual: generate an insight and verify 6 icon cards appear above Key Recommendations
- [ ] Manual: verify grid collapses to single column on mobile
- [ ] Manual: verify cards show correct icons and content

🤖 Generated with [Claude Code](https://claude.com/claude-code)