### PR TITLE
Add optional client brief input with summariser

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -30,6 +30,7 @@ class InsightsRequest(BaseModel):
     advertiser: str
     kpi: str
     include_google_trends: bool = True
+    client_brief: str = ""
 
 
 @app.post("/api/insights")
@@ -42,6 +43,7 @@ def create_insights(req: InsightsRequest):
             advertiser=req.advertiser,
             kpi=req.kpi,
             include_google_trends=req.include_google_trends,
+            client_brief=req.client_brief,
         )
         return result
     except Exception as e:

--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -36,6 +36,7 @@ interface InsightsResult {
   audience_timing: string;
   google_trends: string;
   format_recommendations: string;
+  client_brief_summary: string;
 }
 
 function SkeletonCard() {
@@ -164,6 +165,7 @@ export default function InsightsTool() {
   const [topic, setTopic] = useState("");
   const [advertiser, setAdvertiser] = useState("");
   const [kpi, setKpi] = useState("");
+  const [clientBrief, setClientBrief] = useState("");
   const [includeTrends, setIncludeTrends] = useState(true);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<InsightsResult | null>(null);
@@ -187,6 +189,7 @@ export default function InsightsTool() {
           advertiser: advertiser.trim(),
           kpi,
           include_google_trends: includeTrends,
+          client_brief: clientBrief.trim(),
         }),
       });
 
@@ -263,6 +266,19 @@ export default function InsightsTool() {
                   ))}
                 </select>
               </div>
+            </div>
+
+            <div className="mb-6">
+              <label className="text-[10px] font-bold tracking-widest text-on-surface-variant uppercase mb-2 block">
+                Client Brief (optional)
+              </label>
+              <textarea
+                value={clientBrief}
+                onChange={(e) => setClientBrief(e.target.value)}
+                placeholder="e.g. Client wants to drive awareness among 25-34 women, launching a new skincare range in September, budget is mid-tier, open to digital and social formats"
+                rows={3}
+                className="w-full bg-surface-container-lowest border border-outline-variant rounded-xl px-4 py-3 text-on-surface placeholder-slate-500 focus:outline-none focus:border-accent-cyan focus:shadow-[0_0_0_1px_rgba(31,137,223,0.3)] transition-all resize-y"
+              />
             </div>
 
             <div className="flex items-center justify-between">
@@ -445,6 +461,15 @@ export default function InsightsTool() {
                 <CollapsiblePanel title="Format Recommendations" defaultOpen={false}>
                   <p className="text-on-surface-variant text-sm leading-relaxed whitespace-pre-wrap">
                     {result.format_recommendations}
+                  </p>
+                </CollapsiblePanel>
+              )}
+
+              {/* Client Brief panel */}
+              {result.client_brief_summary && result.client_brief_summary !== "No client brief provided." && (
+                <CollapsiblePanel title="Client Brief" defaultOpen={false}>
+                  <p className="text-on-surface-variant text-sm leading-relaxed whitespace-pre-wrap">
+                    {result.client_brief_summary}
                   </p>
                 </CollapsiblePanel>
               )}

--- a/src/brief.py
+++ b/src/brief.py
@@ -1,0 +1,31 @@
+from openai import OpenAI
+
+import config
+
+SUMMARISER_PROMPT = """Summarise the following client brief into 2-3 concise sentences. Preserve key specifics: audience demographics, budget tier, timeline dates, campaign type, creative requirements, and stated objectives. Do not add information that is not in the original brief. If the input is already very short, return it largely unchanged.
+
+Client brief:
+{raw_brief}"""
+
+
+def summarise_brief(raw_text):
+    # type: (str) -> str
+    """Summarise a client brief into 2-3 sentences via GPT-4o.
+
+    Returns a fallback string if input is empty or whitespace-only.
+    """
+    if not raw_text or not raw_text.strip():
+        return "No client brief provided."
+
+    client = OpenAI(api_key=config.OPENAI_API_KEY)
+    response = client.chat.completions.create(
+        model=config.CHAT_MODEL,
+        messages=[
+            {"role": "system", "content": "You are a concise summariser. Produce only the summary, nothing else."},
+            {"role": "user", "content": SUMMARISER_PROMPT.format(raw_brief=raw_text.strip())},
+        ],
+        temperature=0.2,
+        max_tokens=200,
+    )
+
+    return response.choices[0].message.content

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -58,6 +58,8 @@ For each recommendation:
 - Explain how it aligns with the advertiser's known strategy, campaigns, or brand values from the research
 - Where the research includes source links, include them as references so the reader can verify the evidence
 
+Where a client brief is provided, tailor all sections to the client's stated objectives, constraints, and requirements. Reference client brief context in your recommendations where relevant. If no client brief is provided, proceed based on the other data sources alone.
+
 Be specific and actionable. Avoid generic marketing advice. Ground every recommendation in the data provided. Preserve source links from the advertiser research as inline references throughout the brief. If Google Trends data is unavailable, note this explicitly rather than ignoring it."""
 
 USER_PROMPT_TEMPLATE = """Generate a strategic insights brief for the following:
@@ -65,6 +67,11 @@ USER_PROMPT_TEMPLATE = """Generate a strategic insights brief for the following:
 **Topic:** {topic}
 **Advertiser:** {advertiser}
 **KPI:** {advertiser_kpi}
+
+---
+
+### Client Brief
+{client_brief}
 
 ---
 

--- a/src/synthesiser.py
+++ b/src/synthesiser.py
@@ -4,6 +4,7 @@ from src.vectorstore import search_transcripts
 from src.web_search import research_advertiser
 from src.audience import load_audience_data, get_topic_trends
 from src.trends import get_trend_data
+from src.brief import summarise_brief
 from src.formats import load_format_data
 from src.prompts import SYSTEM_PROMPT, USER_PROMPT_TEMPLATE
 
@@ -47,6 +48,7 @@ def generate_insights(
     advertiser: str,
     kpi: str,
     include_google_trends: bool = True,
+    client_brief: str = "",
 ) -> dict:
     """Main pipeline: gather data from all sources, synthesise with GPT-4o.
 
@@ -75,7 +77,10 @@ def generate_insights(
     # 5. Load format recommendations
     format_recommendations = load_format_data()
 
-    # 6. Assemble prompt
+    # 6. Summarise client brief if provided
+    client_brief_summary = summarise_brief(client_brief)
+
+    # 7. Assemble prompt
     user_prompt = USER_PROMPT_TEMPLATE.format(
         topic=topic,
         advertiser=advertiser,
@@ -85,9 +90,10 @@ def generate_insights(
         audience_timing=audience_timing,
         google_trends=google_trends,
         format_recommendations=format_recommendations,
+        client_brief=client_brief_summary,
     )
 
-    # 7. Call GPT-4o
+    # 8. Call GPT-4o
     client = OpenAI(api_key=config.OPENAI_API_KEY)
     response = client.chat.completions.create(
         model=config.CHAT_MODEL,
@@ -108,4 +114,5 @@ def generate_insights(
         "audience_timing": audience_timing,
         "google_trends": google_trends,
         "format_recommendations": format_recommendations,
+        "client_brief_summary": client_brief_summary,
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -124,6 +124,7 @@ def test_insights_passes_correct_arguments_to_generate_insights():
         advertiser="NutriCo",
         kpi="Awareness",
         include_google_trends=False,
+        client_brief="",
     )
 
 
@@ -142,6 +143,7 @@ def test_insights_include_google_trends_defaults_to_true():
         advertiser="Airwaves",
         kpi="Viewability",
         include_google_trends=True,
+        client_brief="",
     )
 
 

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch, MagicMock
+
+from src.brief import summarise_brief
+
+
+def test_summarise_brief_empty_input_returns_fallback():
+    """summarise_brief() should return fallback string for empty input without calling GPT-4o."""
+    with patch("src.brief.OpenAI") as mock_openai_cls:
+        result = summarise_brief("")
+
+        assert "No client brief provided" in result
+        mock_openai_cls.assert_not_called()
+
+
+def test_summarise_brief_non_empty_calls_gpt_and_returns_summary():
+    """summarise_brief() should call GPT-4o for non-empty input and return the response."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Client seeks Gen Z awareness for skincare launch."
+
+    with patch("src.brief.OpenAI") as mock_openai_cls:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_cls.return_value = mock_client
+
+        result = summarise_brief("Big long brief about skincare targeting Gen Z with awareness goals")
+
+        assert result == "Client seeks Gen Z awareness for skincare launch."
+        mock_client.chat.completions.create.assert_called_once()
+
+
+def test_summarise_brief_whitespace_only_returns_fallback():
+    """summarise_brief() should treat whitespace-only input as empty."""
+    with patch("src.brief.OpenAI") as mock_openai_cls:
+        result = summarise_brief("   \n  ")
+
+        assert "No client brief provided" in result
+        mock_openai_cls.assert_not_called()

--- a/tests/test_synthesiser.py
+++ b/tests/test_synthesiser.py
@@ -58,6 +58,11 @@ def test_system_prompt_at_a_glance_has_fixed_labels():
     assert "Top Format" in glance_section
 
 
+def test_system_prompt_has_client_brief_instruction():
+    """SYSTEM_PROMPT should instruct GPT-4o to tailor sections to the client brief."""
+    assert "client brief" in SYSTEM_PROMPT.lower()
+
+
 def test_system_prompt_has_recommended_products_section():
     """SYSTEM_PROMPT should contain a Recommended Products output section."""
     assert "Recommended Products" in SYSTEM_PROMPT
@@ -98,6 +103,7 @@ def test_user_prompt_template_has_placeholders():
     assert "{google_trends}" in USER_PROMPT_TEMPLATE
     assert "{advertiser_kpi}" in USER_PROMPT_TEMPLATE
     assert "{format_recommendations}" in USER_PROMPT_TEMPLATE
+    assert "{client_brief}" in USER_PROMPT_TEMPLATE
 
 
 def test_user_prompt_renders():
@@ -110,6 +116,7 @@ def test_user_prompt_renders():
         audience_timing="some timing",
         google_trends="some trends",
         format_recommendations="some formats",
+        client_brief="some brief",
     )
     assert "test topic" in rendered
     assert "test brand" in rendered


### PR DESCRIPTION
## Summary
- New `src/brief.py` module with `summarise_brief()` — dedicated GPT-4o call (temperature=0.2, max_tokens=200) that normalises any-length client brief into a consistent 2-3 sentence summary
- Empty input returns fallback string without making an API call
- `SYSTEM_PROMPT` gains explicit instruction to tailor all sections to client brief context
- `USER_PROMPT_TEMPLATE` gains `### Client Brief` section with `{client_brief}` placeholder
- Pipeline wired: summariser called if brief provided, summary injected into prompt and returned in API response
- `InsightsRequest` gains optional `client_brief` field (defaults to empty string)
- Frontend: full-width textarea below input grid with example-led placeholder, collapsible panel for summarised brief in results
- 3 new summariser tests, 2 new prompt tests, updated API and render tests — 56/56 pass

Closes #18, closes #19
Parent PRD: #17

## Test plan
- [x] `python3 -m pytest tests/ -v` — 56/56 pass
- [x] Frontend builds clean (`npx next build`)
- [ ] Manual: generate insight without brief — verify identical behaviour to before
- [ ] Manual: paste a multi-paragraph brief, generate insight — verify summarised brief in collapsible panel and recommendations tailored to brief context
- [ ] Manual: paste a single sentence brief — verify it passes through largely unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)