### PR TITLE
Upgrade insights cards to Prism Deep Sea design system

### DIFF
--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -6,7 +6,6 @@ import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import GlassCard from "@/components/GlassCard";
 import CollapsiblePanel from "@/components/CollapsiblePanel";
-import StatusDot from "@/components/StatusDot";
 
 interface Source {
   editor: string;
@@ -110,33 +109,71 @@ const markdownComponents = {
 
 const GLANCE_ICONS: Record<string, React.ReactNode> = {
   "Core Products": (
-    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15.75 10.5V6a3.75 3.75 0 10-7.5 0v4.5m11.356-1.993l1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 01-1.12-1.243l1.264-12A1.125 1.125 0 015.513 7.5h12.974c.576 0 1.059.435 1.119 1.007zM8.625 10.5a.375.375 0 11-.75 0 .375.375 0 01.75 0zm7.5 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
     </svg>
   ),
   "Latest News": (
-    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 01-2.25 2.25M16.5 7.5V18a2.25 2.25 0 002.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 002.25 2.25h13.5M6 7.5h3v3H6v-3z" />
     </svg>
   ),
   "Messaging": (
-    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 110-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 01-1.44-4.282m3.102.069a18.03 18.03 0 01-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 018.835 2.535M10.34 6.66a23.847 23.847 0 008.835-2.535m0 0A23.74 23.74 0 0018.795 3m.38 1.125a23.91 23.91 0 011.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 001.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 010 3.46" />
     </svg>
   ),
   "Tone": (
-    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.53 16.122a3 3 0 00-5.78 1.128 2.25 2.25 0 01-2.4 2.245 4.5 4.5 0 008.4-2.245c0-.399-.078-.78-.22-1.128zm0 0a15.998 15.998 0 003.388-1.62m-5.043-.025a15.994 15.994 0 011.622-3.395m3.42 3.42a15.995 15.995 0 004.764-4.648l3.876-5.814a1.151 1.151 0 00-1.597-1.597L14.146 6.32a15.996 15.996 0 00-4.649 4.763m3.42 3.42a6.776 6.776 0 00-3.42-3.42" />
     </svg>
   ),
   "Editor Voice": (
-    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
     </svg>
   ),
   "Top Format": (
-    <svg className="w-5 h-5 text-accent-cyan" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+    </svg>
+  ),
+};
+
+const SECTION_ICONS: Record<string, React.ReactNode> = {
+  "Key Recommendations": (
+    <svg className="w-7 h-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z" />
+    </svg>
+  ),
+  "Advertiser Overview": (
+    <svg className="w-7 h-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z" />
+    </svg>
+  ),
+  "Editorial Insights": (
+    <svg className="w-7 h-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 18v-5.25m0 0a6.01 6.01 0 001.5-.189m-1.5.189a6.01 6.01 0 01-1.5-.189m3.75 7.478a12.06 12.06 0 01-4.5 0m3.75 2.383a14.406 14.406 0 01-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 10-7.517 0c.85.493 1.509 1.333 1.509 2.316V18" />
+    </svg>
+  ),
+  "Strategic Alignment": (
+    <svg className="w-7 h-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M14.25 6.087c0-.355.186-.676.401-.959.221-.29.349-.634.349-1.003 0-1.036-1.007-1.875-2.25-1.875s-2.25.84-2.25 1.875c0 .369.128.713.349 1.003.215.283.401.604.401.959v0a.64.64 0 01-.657.643 48.491 48.491 0 01-4.163-.3c.186 1.613.95 3.033 2.07 4.067v0a.64.64 0 010 .918 48.523 48.523 0 01-1.834 1.607c1.175.906 2.627 1.403 4.159 1.403s2.984-.497 4.159-1.403a48.57 48.57 0 01-1.834-1.607.64.64 0 010-.918v0c1.12-1.034 1.884-2.454 2.07-4.067a48.49 48.49 0 01-4.163.3.64.64 0 01-.657-.643v0z" />
+    </svg>
+  ),
+  "Audience Timing": (
+    <svg className="w-7 h-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  "Recommended Products": (
+    <svg className="w-7 h-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+    </svg>
+  ),
+  "Messaging & Tone Recommendations": (
+    <svg className="w-7 h-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 110-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 01-1.44-4.282m3.102.069a18.03 18.03 0 01-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 018.835 2.535M10.34 6.66a23.847 23.847 0 008.835-2.535m0 0A23.74 23.74 0 0018.795 3m.38 1.125a23.91 23.91 0 011.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 001.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 010 3.46" />
     </svg>
   ),
 };
@@ -336,17 +373,15 @@ export default function InsightsTool() {
             <div className="space-y-6">
               {/* At a Glance dashboard */}
               {glanceCards.length > 0 && (
-                <GlassCard>
-                  <div className="mb-4">
-                    <StatusDot label="At a Glance" />
-                  </div>
+                <div className="bg-surface-container-lowest rounded-2xl p-8 border border-white/5">
+                  <h2 className="font-headline text-2xl font-bold mb-6">At a Glance</h2>
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                     {glanceCards.map((card, i) => (
                       <div
                         key={i}
-                        className="bg-surface-container-lowest rounded-xl p-4 border border-white/5 flex items-start gap-3"
+                        className="bg-surface-container rounded-xl p-4 border border-white/5 hover:border-accent-cyan/20 transition-all duration-500 flex items-start gap-3"
                       >
-                        <div className="shrink-0 mt-0.5">
+                        <div className="shrink-0 inline-flex p-2.5 rounded-xl bg-accent-cyan/10 text-accent-cyan">
                           {GLANCE_ICONS[card.label] || GLANCE_ICONS["Core Products"]}
                         </div>
                         <div>
@@ -360,15 +395,16 @@ export default function InsightsTool() {
                       </div>
                     ))}
                   </div>
-                </GlassCard>
+                </div>
               )}
 
               {/* Executive summary banner */}
               {keyRecs && keyRecs.content && (
-                <div className="glass-card rounded-2xl p-6 border border-white/10 shadow-2xl border-l-4 border-l-accent-cyan">
-                  <div className="mb-4">
-                    <StatusDot label="Key Recommendations" />
+                <div className="bg-surface-container-lowest rounded-2xl p-8 border border-white/5 border-l-4 border-l-accent-cyan">
+                  <div className="mb-6 inline-flex p-3 rounded-xl bg-accent-cyan/10 text-accent-cyan">
+                    {SECTION_ICONS["Key Recommendations"]}
                   </div>
+                  <h2 className="font-headline text-2xl font-bold mb-4">Key Recommendations</h2>
                   <div className="text-on-surface-variant text-sm leading-relaxed break-words-anywhere">
                     <ReactMarkdown components={markdownComponents}>
                       {keyRecs.content}
@@ -379,16 +415,22 @@ export default function InsightsTool() {
 
               {/* Detail section cards */}
               {detailSections.map((section, i) => (
-                <GlassCard key={i}>
-                  <div className="mb-4">
-                    <StatusDot label={section.title} />
-                  </div>
+                <div
+                  key={i}
+                  className="bg-surface-container-lowest rounded-2xl p-8 border border-white/5 hover:border-accent-cyan/20 transition-all duration-500"
+                >
+                  {SECTION_ICONS[section.title] && (
+                    <div className="mb-6 inline-flex p-3 rounded-xl bg-accent-cyan/10 text-accent-cyan">
+                      {SECTION_ICONS[section.title]}
+                    </div>
+                  )}
+                  <h2 className="font-headline text-2xl font-bold mb-4">{section.title}</h2>
                   <div className="text-on-surface-variant text-sm leading-relaxed break-words-anywhere">
                     <ReactMarkdown components={markdownComponents}>
                       {section.content}
                     </ReactMarkdown>
                   </div>
-                </GlassCard>
+                </div>
               ))}
 
               {/* Sources panel */}

--- a/frontend/components/CollapsiblePanel.tsx
+++ b/frontend/components/CollapsiblePanel.tsx
@@ -16,7 +16,7 @@ export default function CollapsiblePanel({
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   return (
-    <div className="glass-card rounded-2xl border border-white/10 shadow-2xl overflow-hidden">
+    <div className="bg-surface-container rounded-2xl border border-white/5 overflow-hidden">
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="w-full flex items-center justify-between p-6 text-left hover:bg-white/5 transition-colors"


### PR DESCRIPTION
## Summary
- Detail section cards: replaced GlassCard with solid `bg-surface-container-lowest`, `p-8` padding, `font-headline text-2xl font-bold` headings, icon badges in `bg-accent-cyan/10` containers, `hover:border-accent-cyan/20` transitions
- Key Recommendations: retains cyan left border, upgraded internals to match (solid background, icon badge, larger heading)
- At a Glance: icons upgraded to `w-6 h-6` in `bg-accent-cyan/10 rounded-xl p-2.5` badges, parent swapped from GlassCard to solid surface
- CollapsiblePanel: `glass-card` → `bg-surface-container`, removed `shadow-2xl`, lighter "supporting data" tier
- StatusDot import removed from page.tsx (no longer used)
- Visual consistency with landing page feature cards per PRISM DESIGN.MD

Closes #23, closes #24, closes #25
Parent PRD: #22

## Test plan
- [x] `python3 -m pytest tests/ -v` — 56/56 pass
- [x] Frontend builds clean (`npx next build`)
- [ ] Manual: compare insights cards with landing page feature cards for visual consistency
- [ ] Manual: verify hover effects on detail sections
- [ ] Manual: verify collapsible panels are visually lighter than detail sections
- [ ] Manual: verify mobile responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)