### PR TITLE
Rebrand to Prism Plan & clean up navigation

### DIFF
--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -248,12 +248,21 @@ export default function InsightsTool() {
     <>
       <Navbar />
 
-      <main className="pt-32 pb-20 px-4 md:px-8 min-h-screen">
+      <main className="pt-32 pb-20 px-4 md:px-8 min-h-screen relative">
+        {/* Decorative floating cube */}
+        <div className="absolute top-24 right-8 animate-float pointer-events-none opacity-20 hidden lg:block">
+          <img
+            src="/cube.png"
+            alt=""
+            className="w-24 h-24"
+          />
+        </div>
+
         <div className="max-w-5xl mx-auto">
           {/* Page header */}
           <div className="mb-12">
             <h1 className="font-headline text-4xl md:text-5xl font-extrabold tracking-tighter mb-4">
-              Editorial <span className="text-accent-cyan italic">Insights</span>
+              Prism <span className="text-accent-cyan italic">Plan</span>
             </h1>
             <p className="text-slate-400 text-lg max-w-2xl">
               Generate strategic advertising briefs by combining editorial expertise,

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -15,9 +15,9 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "Prism Data Vault | Editorial Data Vault",
+  title: "Prism Plan | The 3D View Of Your Audience",
   description:
-    "Generate strategic advertising insights by combining editorial expertise, brand research, audience data, and market trends.",
+    "The 1st party planning tool combining behavioural data, editorial expertise, and brand research for tailored advertising recommendations.",
 };
 
 export default function RootLayout({

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -17,15 +17,17 @@ export default function LandingPage() {
 
         <div className="max-w-screen-2xl mx-auto grid grid-cols-1 lg:grid-cols-12 gap-16 items-center relative z-10 w-full">
           <div className="lg:col-span-7">
-            <StatusDot label="v2.4 Deployed" />
+            <StatusDot label="Beta" />
             <h1 className="font-headline text-6xl md:text-8xl font-extrabold tracking-tighter leading-[0.95] mb-8 mt-8">
               The <span className="text-accent-cyan italic">3D View</span> Of
               <br />Your Audience
             </h1>
             <p className="text-xl md:text-2xl text-slate-400 max-w-2xl font-light leading-relaxed mb-12">
-              Tap into our proprietary vault of deep editorial expertise,
-              behavioural data, panel research and more for unique insight and
-              guidance on how to reach and message your audience.
+              The 1st party planning tool that draws on our extensive behavioural
+              data, in house research, advertiser understanding and deep editorial
+              expertise for{" "}
+              <span className="text-accent-cyan font-medium">tailored recommendations</span>{" "}
+              on every brief.
             </p>
             <div className="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-6">
               <Link href="/app">
@@ -44,7 +46,7 @@ export default function LandingPage() {
             <div className="animate-float relative">
               <img
                 src="/cube.png"
-                alt="Refractive Monolith Cube"
+                alt="Prism Plan cube"
                 className="monolith-cube w-full max-w-[420px]"
               />
               <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-3/4 h-3/4 bg-primary/20 blur-[120px] rounded-full -z-10" />
@@ -53,15 +55,47 @@ export default function LandingPage() {
         </div>
       </header>
 
-      {/* Feature Bento Grid */}
-      <section className="py-32 px-8 bg-surface-container-low border-y border-white/5 relative overflow-hidden">
+      {/* Features */}
+      <section id="features" className="py-32 px-8 bg-surface-container-low border-y border-white/5 relative overflow-hidden">
         <div className="max-w-screen-2xl mx-auto relative z-10">
           <SectionHeading>
-            Precision-Engineered <br />
-            Capabilities.
+            Data-Driven <br />
+            Planning.
           </SectionHeading>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            {/* Feature 1 */}
+            {/* Editorial Intelligence */}
+            <div className="group bg-surface-container-lowest p-10 rounded-2xl border border-white/5 hover:border-accent-cyan/20 transition-all duration-500 relative overflow-hidden">
+              <div className="mb-8 inline-flex p-4 rounded-xl bg-accent-cyan/10 text-accent-cyan group-hover:bg-accent-cyan group-hover:text-white transition-colors relative z-10">
+                <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+                </svg>
+              </div>
+              <h3 className="font-headline text-2xl font-bold mb-4 relative z-10">
+                Editorial Intelligence
+              </h3>
+              <p className="text-slate-400 leading-relaxed relative z-10">
+                Draws on in-house editorial expertise and transcripts to surface
+                the themes and angles that resonate with your audience.
+              </p>
+            </div>
+
+            {/* Brand Research — elevated */}
+            <div className="group bg-surface-container-highest p-10 rounded-2xl border border-white/5 hover:border-accent-cyan/20 transition-all duration-500 transform lg:scale-105 shadow-2xl relative overflow-hidden">
+              <div className="mb-8 inline-flex p-4 rounded-xl bg-accent-cyan/10 text-accent-cyan group-hover:bg-accent-cyan group-hover:text-white transition-colors relative z-10">
+                <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+                </svg>
+              </div>
+              <h3 className="font-headline text-2xl font-bold mb-4 relative z-10">
+                Brand Research
+              </h3>
+              <p className="text-slate-400 leading-relaxed relative z-10">
+                Automated advertiser analysis via web research, uncovering brand
+                positioning, campaigns, and market context.
+              </p>
+            </div>
+
+            {/* Audience & Trends */}
             <div className="group bg-surface-container-lowest p-10 rounded-2xl border border-white/5 hover:border-accent-cyan/20 transition-all duration-500 relative overflow-hidden">
               <div className="mb-8 inline-flex p-4 rounded-xl bg-accent-cyan/10 text-accent-cyan group-hover:bg-accent-cyan group-hover:text-white transition-colors relative z-10">
                 <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -69,208 +103,65 @@ export default function LandingPage() {
                 </svg>
               </div>
               <h3 className="font-headline text-2xl font-bold mb-4 relative z-10">
-                Real-time Analytics
+                Audience & Trends
               </h3>
               <p className="text-slate-400 leading-relaxed relative z-10">
-                Latency-free data streaming across global nodes with millisecond
-                accuracy and refractive processing.
-              </p>
-            </div>
-
-            {/* Feature 2 — elevated */}
-            <div className="group bg-surface-container-highest p-10 rounded-2xl border border-white/5 hover:border-accent-cyan/20 transition-all duration-500 transform lg:scale-105 shadow-2xl relative overflow-hidden">
-              <div className="mb-8 inline-flex p-4 rounded-xl bg-accent-cyan/10 text-accent-cyan group-hover:bg-accent-cyan group-hover:text-white transition-colors relative z-10">
-                <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
-                </svg>
-              </div>
-              <h3 className="font-headline text-2xl font-bold mb-4 relative z-10">
-                Secure Vaulting
-              </h3>
-              <p className="text-slate-400 leading-relaxed relative z-10">
-                Quantum-resistant encryption layers that wrap your data in an
-                impenetrable deep-sea security shell.
-              </p>
-            </div>
-
-            {/* Feature 3 */}
-            <div className="group bg-surface-container-lowest p-10 rounded-2xl border border-white/5 hover:border-accent-cyan/20 transition-all duration-500 relative overflow-hidden">
-              <div className="mb-8 inline-flex p-4 rounded-xl bg-accent-cyan/10 text-accent-cyan group-hover:bg-accent-cyan group-hover:text-white transition-colors relative z-10">
-                <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456z" />
-                </svg>
-              </div>
-              <h3 className="font-headline text-2xl font-bold mb-4 relative z-10">
-                AI-Powered Insights
-              </h3>
-              <p className="text-slate-400 leading-relaxed relative z-10">
-                Self-learning algorithms that predict data bottlenecks before
-                they happen, optimizing your entire ecosystem.
+                Behavioural data and real-time Google Trends signals to identify
+                when and how your audience is most engaged.
               </p>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Testimonial */}
+      {/* Data Sources Showcase */}
       <section className="py-32 px-8">
         <div className="max-w-screen-2xl mx-auto">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-24 items-center">
             <div>
-              <svg
-                className="text-accent-cyan w-16 h-16 mb-8"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path d="M14.017 21v-7.391c0-5.704 3.731-9.57 8.983-10.609l.995 2.151c-2.432.917-3.995 3.638-3.995 5.849h4v10H14.017zM0 21v-7.391c0-5.704 3.731-9.57 8.983-10.609l.995 2.151C7.546 6.068 5.983 8.789 5.983 11h4v10H0z" />
-              </svg>
-              <blockquote className="text-4xl md:text-5xl font-headline font-bold leading-tight mb-10">
-                &ldquo;Prism changed how we perceive data. It&rsquo;s no longer
-                just a resource; it&rsquo;s our primary competitive
-                advantage.&rdquo;
-              </blockquote>
-              <div className="flex items-center space-x-4">
-                <div className="w-16 h-16 rounded-full bg-surface-container-high border border-white/10 flex items-center justify-center text-accent-cyan font-headline font-bold text-xl">
-                  ES
-                </div>
-                <div>
-                  <p className="font-headline font-bold text-lg">
-                    Elena Sterling
-                  </p>
-                  <p className="text-accent-cyan text-[10px] font-bold tracking-[0.2em] uppercase">
-                    CTO, NexaCorp Enterprise
-                  </p>
-                </div>
-              </div>
+              <h2 className="text-4xl md:text-5xl font-headline font-bold leading-tight mb-6">
+                Four data sources.{" "}
+                <span className="text-accent-cyan">One unified strategy.</span>
+              </h2>
+              <p className="text-xl text-slate-400 leading-relaxed">
+                Every Prism Plan synthesises editorial expertise, brand intelligence,
+                audience behaviour, and live trend data into a single, actionable
+                advertising recommendation.
+              </p>
             </div>
 
-            {/* Partner logos grid */}
+            {/* Data source cards */}
             <div className="grid grid-cols-2 gap-8">
-              {["GLOBAL_CORE", "AETHER_UI", "SYNTH_SYS", "PRISM_FLOW"].map(
-                (name) => (
-                  <div
-                    key={name}
-                    className="h-32 flex items-center justify-center grayscale opacity-30 hover:opacity-100 hover:grayscale-0 transition-all bg-surface-container-low rounded-xl border border-white/5 overflow-hidden group"
-                  >
-                    <span className="font-headline font-black text-2xl tracking-tighter relative z-10">
-                      {name}
-                    </span>
-                  </div>
-                )
-              )}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Pricing */}
-      <section id="pricing" className="py-32 px-8 bg-surface-container-lowest">
-        <div className="max-w-screen-2xl mx-auto">
-          <div className="text-center mb-20">
-            <h2 className="font-headline text-5xl font-extrabold mb-6">
-              Tailored Performance
-            </h2>
-            <p className="text-slate-400 max-w-xl mx-auto">
-              Choose the clarity level that matches your organizational scale.
-            </p>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-0 border border-white/10 rounded-3xl overflow-hidden shadow-2xl">
-            {/* Essential */}
-            <div className="p-12 bg-surface-container border-r border-white/5 flex flex-col">
-              <h3 className="text-xl font-headline font-bold mb-2">
-                Essential
-              </h3>
-              <p className="text-slate-500 text-sm mb-8">For emerging teams</p>
-              <div className="mb-10">
-                <span className="text-5xl font-headline font-bold">$49</span>
-                <span className="text-outline">/mo</span>
-              </div>
-              <ul className="space-y-4 mb-12 flex-grow">
-                {["1TB Secure Storage", "Basic Analytics", "Email Support"].map(
-                  (item) => (
-                    <li
-                      key={item}
-                      className="flex items-center space-x-3 text-slate-400"
-                    >
-                      <svg className="w-4 h-4 text-accent-cyan flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                        <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-                      </svg>
-                      <span>{item}</span>
-                    </li>
-                  )
-                )}
-              </ul>
-              <button className="w-full py-4 border border-white/10 rounded-xl font-bold hover:bg-surface-bright transition-colors">
-                Select Essential
-              </button>
-            </div>
-
-            {/* Professional */}
-            <div className="p-12 bg-surface-container-high border-r border-white/5 flex flex-col relative overflow-hidden">
-              <div className="absolute top-4 right-12 bg-accent-cyan text-white text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-widest">
-                Recommended
-              </div>
-              <h3 className="text-xl font-headline font-bold mb-2">
-                Professional
-              </h3>
-              <p className="text-slate-500 text-sm mb-8">
-                For scaling organizations
-              </p>
-              <div className="mb-10">
-                <span className="text-5xl font-headline font-bold">$199</span>
-                <span className="text-outline">/mo</span>
-              </div>
-              <ul className="space-y-4 mb-12 flex-grow">
-                {[
-                  "Unlimited Storage",
-                  "Advanced AI Insights",
-                  "API Access",
-                  "24/7 Priority Support",
-                ].map((item) => (
-                  <li key={item} className="flex items-center space-x-3">
-                    <svg className="w-4 h-4 text-accent-cyan flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-                    </svg>
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-              <button className="w-full py-4 refractive-gradient rounded-xl font-bold text-white shadow-lg">
-                Scale Up Now
-              </button>
-            </div>
-
-            {/* Enterprise */}
-            <div className="p-12 bg-surface-container flex flex-col">
-              <h3 className="text-xl font-headline font-bold mb-2">
-                Enterprise
-              </h3>
-              <p className="text-slate-500 text-sm mb-8">
-                For global infrastructure
-              </p>
-              <div className="mb-10">
-                <span className="text-5xl font-headline font-bold">Custom</span>
-              </div>
-              <ul className="space-y-4 mb-12 flex-grow">
-                {[
-                  "Dedicated Nodes",
-                  "SLA Guarantees",
-                  "Custom Integrations",
-                ].map((item) => (
-                  <li
-                    key={item}
-                    className="flex items-center space-x-3 text-slate-400"
-                  >
-                    <svg className="w-4 h-4 text-accent-cyan flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-                    </svg>
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-              <button className="w-full py-4 border border-white/10 rounded-xl font-bold hover:bg-surface-bright transition-colors">
-                Contact Sales
-              </button>
+              {[
+                {
+                  title: "Editorial Transcripts",
+                  description: "In-depth editor interviews surfacing themes, angles, and audience sentiment.",
+                },
+                {
+                  title: "Brand Research",
+                  description: "Automated web research into advertiser positioning, campaigns, and competitors.",
+                },
+                {
+                  title: "Audience Data",
+                  description: "Behavioural engagement trends revealing when and how audiences respond.",
+                },
+                {
+                  title: "Google Trends",
+                  description: "Real-time search interest, related queries, and multi-timeframe analysis.",
+                },
+              ].map((source) => (
+                <div
+                  key={source.title}
+                  className="p-6 bg-surface-container-low rounded-xl border border-white/5 hover:border-accent-cyan/20 transition-all duration-300"
+                >
+                  <h4 className="font-headline font-bold text-lg mb-2">
+                    {source.title}
+                  </h4>
+                  <p className="text-slate-500 text-sm leading-relaxed">
+                    {source.description}
+                  </p>
+                </div>
+              ))}
             </div>
           </div>
         </div>
@@ -281,22 +172,17 @@ export default function LandingPage() {
         <div className="absolute inset-0 bg-primary/20 -skew-y-6 translate-y-24" />
         <div className="max-w-4xl mx-auto text-center relative z-10">
           <h2 className="font-headline text-5xl md:text-7xl font-extrabold tracking-tight mb-8">
-            Ready to Secure Your Future?
+            Build your Prism Plan
           </h2>
           <p className="text-xl text-slate-400 mb-12 max-w-2xl mx-auto">
-            Join 10,000+ architects who have traded data complexity for
-            architectural clarity.
+            Turn editorial insight, audience data, and brand research into
+            actionable strategy in seconds.
           </p>
-          <div className="inline-flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-6">
-            <Link href="/app">
-              <Button variant="primary" className="text-xl px-12 py-6">
-                Get Started Free
-              </Button>
-            </Link>
-            <Button variant="secondary" className="text-xl px-12 py-6 backdrop-blur-sm">
-              Talk to an Architect
+          <Link href="/app">
+            <Button variant="primary" className="text-xl px-12 py-6">
+              Get Started
             </Button>
-          </div>
+          </Link>
         </div>
       </section>
 

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -1,84 +1,12 @@
 export default function Footer() {
   return (
-    <footer className="w-full pt-20 pb-10 bg-[#05070a] border-t border-white/5">
-      <div className="max-w-screen-2xl mx-auto px-8 grid grid-cols-1 md:grid-cols-4 gap-12 font-body text-sm leading-relaxed">
-        <div className="col-span-1">
-          <div className="text-xl font-bold text-white tracking-tight mb-6 flex items-center gap-2 font-headline">
-            <span className="w-1.5 h-5 bg-accent-cyan rounded-full" />
-            Prism Data Vault
-          </div>
-          <p className="text-slate-500 mb-8">
-            Leading the transition from static storage to dynamic architectural
-            clarity with deep-sea security protocols.
-          </p>
+    <footer className="w-full py-10 bg-[#05070a] border-t border-white/5">
+      <div className="max-w-screen-2xl mx-auto px-8 flex flex-col md:flex-row justify-between items-center text-sm">
+        <div className="flex items-center gap-2 font-headline font-bold text-white tracking-tight mb-4 md:mb-0">
+          <span className="w-1.5 h-5 bg-accent-cyan rounded-full" />
+          Prism Plan
         </div>
-        <div>
-          <h4 className="text-white font-bold mb-6 font-headline">Platform</h4>
-          <ul className="space-y-4 text-slate-500">
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              Vault Engine
-            </li>
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              Analytics
-            </li>
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              Security
-            </li>
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              Integrations
-            </li>
-          </ul>
-        </div>
-        <div>
-          <h4 className="text-white font-bold mb-6 font-headline">Company</h4>
-          <ul className="space-y-4 text-slate-500">
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              About Us
-            </li>
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              Careers
-            </li>
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              Press
-            </li>
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              Contact
-            </li>
-          </ul>
-        </div>
-        <div>
-          <h4 className="text-white font-bold mb-6 font-headline">
-            Resources
-          </h4>
-          <ul className="space-y-4 text-slate-500">
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              Security
-            </li>
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              Status
-            </li>
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              Privacy
-            </li>
-            <li className="hover:text-accent-cyan transition-colors duration-200 cursor-pointer">
-              Terms
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div className="max-w-screen-2xl mx-auto px-8 mt-20 pt-8 border-t border-white/5 flex flex-col md:flex-row justify-between items-center text-slate-500">
-        <p>&copy; 2024 Prism Data Vault. Deep-Sea Architectural Clarity.</p>
-        <div className="flex space-x-6 mt-4 md:mt-0">
-          <a href="#" className="hover:text-accent-cyan transition-colors">
-            Privacy
-          </a>
-          <a href="#" className="hover:text-accent-cyan transition-colors">
-            Terms
-          </a>
-          <a href="#" className="hover:text-accent-cyan transition-colors">
-            Sitemap
-          </a>
-        </div>
+        <p className="text-slate-500">&copy; 2026 Prism Plan</p>
       </div>
     </footer>
   );

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -9,40 +9,16 @@ export default function Navbar() {
           className="text-2xl font-bold tracking-tighter text-white font-headline flex items-center gap-2"
         >
           <span className="w-2 h-6 bg-accent-cyan rounded-full" />
-          Prism Data Vault
+          Prism Plan
         </Link>
 
-        <div className="hidden md:flex items-center space-x-10 font-headline font-semibold tracking-tight">
-          <Link
-            href="/"
-            className="text-slate-400 hover:text-white transition-all duration-300"
-          >
-            Products
-          </Link>
-          <Link
-            href="/#pricing"
-            className="text-slate-400 hover:text-white transition-all duration-300"
-          >
-            Pricing
-          </Link>
-          <Link
-            href="/app"
-            className="text-accent-cyan border-b-2 border-accent-cyan pb-1 transition-all duration-300"
-          >
-            Insights Tool
-          </Link>
-          <Link
-            href="/#resources"
-            className="text-slate-400 hover:text-white transition-all duration-300"
-          >
-            Resources
-          </Link>
-        </div>
-
         <div className="flex items-center space-x-6">
-          <button className="text-slate-400 font-semibold hover:text-white active:scale-95 transition-all">
-            Login
-          </button>
+          <Link
+            href="/#features"
+            className="hidden md:inline text-slate-400 hover:text-white transition-all duration-300 font-headline font-semibold tracking-tight"
+          >
+            Features
+          </Link>
           <Link
             href="/app"
             className="refractive-gradient px-6 py-2.5 rounded-xl font-bold text-white shadow-lg active:scale-95 transition-transform inline-block"


### PR DESCRIPTION
## Summary

- Renames "Prism Data Vault" → "Prism Plan" across all frontend surfaces (navbar, footer, metadata, pages)
- Strips navbar down to just **Features** anchor + **Launch App** CTA — removes all dead links (Products, Pricing, Resources, Login)
- Collapses footer from 4-column layout to minimal single row with branding + copyright
- Rewrites landing page: Beta badge, new hero subheading, real feature cards (Editorial Intelligence, Brand Research, Audience & Trends), data sources showcase replacing fake testimonials, "Build your Prism Plan" CTA
- Removes entire pricing section and all fake content (testimonials, partner logos, fictional stats)
- Updates `/app` page heading to "Prism Plan" + adds decorative floating cube

Closes #33, #35, #38, #39, #40, #41
Parent PRD: #27

## Test plan

- [ ] Frontend builds cleanly (`npm run build`)
- [ ] All 56 backend tests pass (`python3 -m pytest tests/ -v`)
- [ ] Landing page renders all 4 sections: Hero, Features, Data Sources, Bottom CTA
- [ ] No pricing section visible
- [ ] Navbar shows only "Features" and "Launch App" links
- [ ] "Features" link scrolls to `/#features` section
- [ ] Footer shows only "Prism Plan" branding and © 2026
- [ ] Browser tab reads "Prism Plan | The 3D View Of Your Audience"
- [ ] `/app` page heading reads "Prism Plan" with floating cube visible on desktop
- [ ] No references to "Data Vault", "deep-sea", "encryption", or fake names remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)