### PR TITLE
Add previous campaign lookup to insights pipeline

### DIFF
--- a/data/campaign_history.csv
+++ b/data/campaign_history.csv
@@ -1,0 +1,2002 @@
+advertiser,campaign_name,campaign_id,category,start_date,impressions,clicks
+Nutracheck,Nutracheck,1856812,On-Demand,2025-01-01,101776567,44762
+Nutracheck,Nutracheck,1856812,On-Demand,2025-01-01,44519144,34225
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,40862256,16443
+Nutracheck,Nutracheck,1856812,On-Demand,2024-01-01,35707683,12298
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,22864578,9632
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,21944080,9286
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,21742705,9116
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,21742417,9026
+Radio Times Marketting,Radio Times Marketting - 2024,1537204,Entertainment,2024-01-01,21727165,0
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2026-01-01,14153650,4102
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,10791997,4581
+BBC Good Food,Husk,2232713,Food,2025-01-01,9294360,3756
+BBC Good Food,GF App House Ads ,2234260,Food,2025-01-01,8605980,3496
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,5611379,3818
+Nutracheck,Nutracheck,1856812,On-Demand,2025-01-01,5568248,5262
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2026-01-01,5220847,1151
+Diageo,ORD-00290179_Diageo_Whisky_Widget_PHD_Jan-June25,1953536,Alcohol,2025-01-01,5046682,7005
+Diageo,ORD-00290179_Diageo_Whisky Widget_PHD_Jan-June25,1938830,Alcohol,2025-01-01,5046682,7005
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2026-01-01,4741773,1931
+Nutracheck,Nutracheck,1856812,On-Demand,2025-01-01,4647153,5606
+Morrisons,ORD-00283323_Morrisons_Wavemaker_May-Nov 2024 partnership,1640453,Supermarket,2024-01-01,4400071,2624
+Sarson's,ORD-00288776_Sarsons Vinegar_Brewed for Food Burst 2_Food_Sep24,1789636,Food,2024-01-01,4247700,42471
+Aldi,ORD-00299514_Direct_AldiEaster2026,2271794,Food,2026-01-01,3944639,1163
+Aldi,ORD-00295386_Direct_Aldi_August_Digi_2025,2080311,Supermarket,2025-01-01,3661025,1679
+Aldi,ORD-00295386_Direct_Aldi_August_Digi_2025,2080311,Supermarket,2025-01-01,3557601,1613
+Diageo,ORD-00282260_ Diageo_Cocktail Widget_PHD_MarJun24,1604691,Alcohol,2024-01-01,3355216,11149
+Audible,Audible_wavemaker_Comedy_July25,2054149,Entertainment,2025-01-01,3333894,32856
+Screw This Podcast - House Campaign ,Screw This Podcast - House Campaign 2026,2241750,On-Demand,2026-01-01,3270835,1097
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2026-01-01,3269604,1097
+Aldi,ORD-00298137_ Direct- Aldi - Starcom - Jan GF - 12/01 - 31/01 2026,2232285,Supermarket,2026-01-01,2991888,10241
+Florette,ORD-00292672_Florette_Caratleeds_Partnership_May-July2025,1993798,Food,2025-01-01,2932228,3259
+Immediate Media,Good Food HDP- 2024,1672285,Food,2024-01-01,2902816,1357
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2026-01-01,2898388,701
+Morrisons,ORD-00283323_Morrisons_Wavemaker_May-Nov 2024 partnership,1640453,Supermarket,2024-01-01,2801451,4279
+Tesco,ORD-00290546 _BARTER Tesco Christmas 2024 Digital Campaign,1866821,Supermarket,2024-01-01,2713520,21092
+BBC Good Food,Husk,2232713,Food,2026-01-01,2624826,599
+Diageo,ORD-00290180_Diageo_Christmas Cocktail Widget_PHD_Oct-Dec24,1888448,Alcohol,2024-01-01,2611724,1274
+Morrisons,ORD-00283323_Morrisons_Wavemaker_May-Nov 2024 partnership,1640453,Supermarket,2024-01-01,2600040,921
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,2523592,574
+BBC Good Food,GF App House Ads ,2234260,Food,2025-01-01,2523592,574
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,2523592,574
+Morrisons,ORD-00292183_Morrisons 2025 partnership_Wavemaker_Feb-Oct25,1940739,Supermarket,2025-01-01,2501135,1244
+Morrisons,ORD-00292183_Morrisons 2025 partnership_Wavemaker_Feb-Oct25,1940739,Supermarket,2025-01-01,2500232,2218
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,2499760,1194
+Sainsburys,ORD-00294588_Sainsbury's x Good Food TTD P2 June-August,2045562,Supermarket,2025-01-01,2472246,28782
+Sainsburys,ORD-00293866_Sainsbury's Q2 TTD Campaign 2025,2003631,Supermarket,2025-01-01,2472230,26805
+Immediate Media,Amazon XCM - Eclipse Takeover. 20/11/25,2187664,Retail,2025-01-01,2457467,28714
+E.ON Smart Energy,ORD-00293708 Direct - Mediaplus_E.ON Next Commodities_Q2_2025,1981579,Tech,2025-01-01,2400909,22934
+Aldi,ORD-00289221_Aldi Christmas Digi 2024,1844309,Supermarket,2024-01-01,2381475,29651
+Jaguar Landrover,ORD-00292004 Direct - AUV_JLR_H&S_Feb-April 2025,1908230,Motoring,2025-01-01,2371423,2937
+Waitrose,PD_Waitrose_Summer-2024_Standard-Banners_17/05-26/08_AT,1775226,Supermarket,2024-01-01,2360383,5769
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2024-01-01,2319885,312
+Tesco,ORD-00288310_Tesco Whoosh - September 2024 Campaign,1773458,Supermarket,2024-01-01,2312584,24308
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2026-01-01,2275743,724
+National Geographic,PG_Nat_Geo_Publicis_Tsunami_Race Against_Time_November,1896920,Entertainment,2024-01-01,2152212,13116
+Centrum,ORD-00291473_Centrum_Spark_Vitamins 2025,1896853,Health,2025-01-01,2140046,965
+Nutracheck,Nutracheck,1856812,On-Demand,2024-01-01,2107921,679
+Aldi,PG_Aldi_May_2025,1995707,Supermarket,2025-01-01,2053772,21489
+Tesco,ORD-00297187_Tesco Christmas 2025,2245164,Food,2025-01-01,2002733,19707
+Sky,ORD-00296626 Sky Publishing campaign- The Iris Affair,2151577,Entertainment,2025-01-01,2000013,20957
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,1999995,854
+Nutracheck,Nutracheck,1856812,On-Demand,2025-01-01,1937911,1353
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2026-01-01,1907370,407
+Aldi,ORD-00294289&ORD-00294893_Direct_Aldi Summer Hub_2025,2023846,Supermarket,2025-01-01,1850682,52380
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1962013,Motoring,2025-01-01,1793422,981
+Jaguar Landrover,ORD-00292004 Direct - AUV_JLR_H&S_Feb-April 2025,1908230,Motoring,2025-01-01,1785660,2675
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,1754460,18651
+Nutracheck,Nutracheck,1856812,On-Demand,2025-01-01,1752426,1621
+Nestle Purina,PG_Nestle_Openmind_Purina Gourmet_05/05/25-29/06/25_RT,2019876,Pets,2025-01-01,1719408,19288
+ITV,ORD-00297090_BARTER ITV I'm A Celeb x Immediate Q4 2025,2171070,Supermarket,2025-01-01,1667101,24512
+Visit Orlando,ORD-00295890 Visit Orlando Display,2161910,Travel,2025-01-01,1643957,20912
+E.ON Smart Energy,ORD-00293708 Direct - Mediaplus_E.ON Next Commodities_Q2_2025,1981579,Tech,2025-01-01,1624442,24094
+Nutracheck,Nutracheck,1856812,On-Demand,2024-01-01,1603418,3054
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1982913,Motoring,2025-01-01,1600629,939
+Waitrose,PG_Waitrose_MGOMD_No1_Oct_LD,2139412,Supermarket,2025-01-01,1593119,15735
+Carte D'Or,ORD-00297006 Direct_Digi_Carte D'Or_Q4 2025,2174656,Food,2025-01-01,1553328,11129
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,1521629,14701
+Morrisons,ORD-00292183_Morrisons 2025 partnership_Wavemaker_Feb-Oct25,1940739,Supermarket,2025-01-01,1500085,24589
+Kerrygold,ORD-00292017_Kerrygold_PHDManchester_partnership2025,1959016,Food,2025-01-01,1500022,302
+Morrisons,ORD-00283323_Morrisons_Wavemaker_May-Nov 2024 partnership,1640453,Supermarket,2024-01-01,1500014,1508
+Morrisons,ORD-00283323_Morrisons_Wavemaker_May-Nov 2024 partnership,1640453,Supermarket,2024-01-01,1500003,1142
+Aldi,ORD-00299514_Direct_AldiEaster2026,2271794,Supermarket,2026-01-01,1493948,16064
+Post Office,ORD-00291044_PostOfficeSavings_TheStoryLab_Sept24-Mar25,1904969,Government,2025-01-01,1480297,657
+Ninja,Shark Ninja,1912836,Tech,2024-01-01,1478457,872
+Morrisons,ORD-00283323_Morrisons_Wavemaker_May-Nov 2024 partnership,1640453,Supermarket,2024-01-01,1450002,29271
+ITV,PG - ITV Red Eye S2 December 2025,2229998,Entertainment,2025-01-01,1409226,16280
+Inspired Villages Group Limited,ORD-00284044_Inspired Villages Soap Awards,1701686,Entertainment,2024-01-01,1409004,7544
+Post Office,ORD-00291044_PostOfficeSavings_TheStoryLab_Sept24-Mar25,1904969,Government,2025-01-01,1408992,550
+Centrum,ORD-00291473_Centrum_Spark_Vitamins 2025,1896853,Health,2025-01-01,1390036,613
+Aldi,PG_Aldi_Sept_Olive_GoodFood,2096740,Supermarket,2025-01-01,1388908,12401
+Aldi,PG_Aldi_Sept_Oct_Olive_GoodFood,2230444,Supermarket,2025-01-01,1388878,13815
+Specsavers ,PG_Specs_MGOMD_OwnedandRun_Oct-Dec_LD,1869417,Health,2024-01-01,1388866,12770
+Aldi,PG_Aldi_Sept_Oct_Olive_GoodFood,2230444,Supermarket,2025-01-01,1388856,12404
+Aldi,PG_Aldi_Sept_Oct_Olive_GoodFood,2230444,Supermarket,2025-01-01,1388852,15726
+Aldi,PG_Aldi_May_2025,1995707,Supermarket,2025-01-01,1388453,14527
+Aldi,PG_Aldi July Digi_2025,2052147,Supermarket,2025-01-01,1388236,45364
+Aldi,ORD-00288560_Aldi Halloween Digi 2024,1787291,Food,2024-01-01,1338726,13494
+HBO Max,ORD-00299155_HBOMAX_Radio_Times_2026,2293143,Entertainment,2026-01-01,1332022,0
+Gousto,ORD-00297780_Gousto_brandpartnership_26,2224957,Supermarket,2026-01-01,1329566,7308
+Aldi,PG_Aldi Jan_Olive_GoodFood_CMT-Which-Promotion,1877160,Supermarket,2025-01-01,1316851,13983
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,1310159,24738
+Spinnaker London,ORD-00291496_European Mushroom_DMPU_MB_GF_JAN'25,1884937,Food,2025-01-01,1300653,1346
+European Mushrooms,ORD-00291496_European Mushroom_DMPU_MB_GF_JAN'25,1901949,Food,2025-01-01,1300215,1346
+Waitrose,ORD-00293374_Direct_Waitrose_MGOMD_Easter25_LD,1969303,Supermarket,2025-01-01,1295114,20002
+Sky,ORD-00296626 Sky Publishing campaign- The Iris Affair,2151577,Entertainment,2025-01-01,1286481,0
+Aldi,PG_Aldi July Digi_2025,2052147,Supermarket,2025-01-01,1283164,14190
+Red Tractor,PG_RedTractor_7stars_RecipeVideoContent_20thOct-30thNov,2158996,Food,2025-01-01,1243008,4745
+Apple,ORD-00291463_Direct_Apple_PrimeTarget_ RT_Jan_LD,1894480,Entertainment,2025-01-01,1239359,19056
+Visa, PG_Visa_Q4_2025_Decembe,2216277,Retail,2025-01-01,1229679,10528
+Visa,PG_Visa_Q4_2025_December&January,2221526,Retail,2025-01-01,1229644,10529
+Arla,ORD-00293208_Arla_Lurpak_Easter_25_Value,1983591,Food,2025-01-01,1222229,7727
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,1221425,12857
+Aldi,ORD-00299514_Direct_AldiEaster2026,2271794,Supermarket,2026-01-01,1209119,15420
+Morrisons,ORD-00283323_Morrisons_Wavemaker_May-Nov 2024 partnership,1640453,Supermarket,2024-01-01,1200012,11366
+Jaguar Landrover,ORD-00292004 Direct - AUV_JLR_H&S_Feb-April 2025,1908230,Motoring,2025-01-01,1200002,711
+Stake,ORD-00293834_Playhill Limited - Stake. Canada Geo Campaign,2017913,Gambling,2025-01-01,1199875,11930
+Holland & Barrett,ORD-00291348_H&B P3 Nutrition_Skins&MMA_Jan 25,1879540,Health,2025-01-01,1190485,12031
+National Geographic,PG_Nat Geo_Zenith_David Blaine_24/03/25,1943612,Entertainment,2025-01-01,1185694,10885
+Nestle - Maggi, PG_Nestle_Maggi_ 10/10-31/12_,1823799,Food,2024-01-01,1182883,312
+Superdrug,ORD-00298203_Direct_Digi_Superdrug_GoodFood_Jan2026,2232195,Health,2026-01-01,1178597,10567
+Specsavers ,PG_Specs_MGOMD_OwnedandRun_Oct-Dec_LD,1869417,Health,2024-01-01,1153797,94
+Immediate Media,Good Food HDP- 2024,1672285,Food,2024-01-01,1150092,485
+Sky,ORD-00291224_sky screen test Lockerbie,1887190,Entertainment,2024-01-01,1150010,1209
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,1150004,16827
+Apple,ORD-00297550_Direct_Apple_Iphone_ RT_/NOVDec_LD,2229907,Entertainment,2025-01-01,1137550,588
+Jaguar Landrover,ORD-00293797_Direct - JLR_Hearts & Science_RRS_Q2,2003597,Motoring,2025-01-01,1125249,645
+TUI,ORD-00288923_TUI_Lanzarote Digi campaign - October 24,1794257,Travel,2024-01-01,1121466,28321
+TUI,ORD-00288923_TUI_Lanzarote Digi campaign - October 24,1794257,Travel,2024-01-01,1120615,2760
+Avios,PG_Avios_MGOMD_TWC_Q4_LD,2193208,Travel,2025-01-01,1118102,19511
+Disney+,PG_Disney_Inside Out 2 D+ Campaign Oct 24,1770302,On-Demand,2024-01-01,1116215,16019
+Jaguar Landrover,ORD-00293797_Direct - JLR_Hearts & Science_RRS_Q2,2003597,Motoring,2025-01-01,1115451,1302
+Jaguar Landrover,ORD-00293797_Direct - JLR_Hearts & Science_RRS_Q2,2003597,Motoring,2025-01-01,1115434,1252
+Aldi,PG_Aldi June Digi_2025,2017650,Supermarket,2025-01-01,1111126,32733
+Aldi,PG_Aldi June Digi_2025,2017650,Supermarket,2025-01-01,1111123,11870
+Aldi,PG_Aldi_August_2025,2074595,Supermarket,2025-01-01,1111120,10940
+Aldi,PG_Aldi_August_2025,2074595,Supermarket,2025-01-01,1111120,34576
+Aldi,PG_Aldi_Sept_Oct_Olive_GoodFood,2230444,Supermarket,2025-01-01,1110817,11416
+Aldi,PG_Aldi_Sept_Oct_Olive_GoodFood,2230444,Supermarket,2025-01-01,1109081,12514
+Nestle - Maggi, PG_Nestle_Maggi_ 10/10-31/12_,1823799,Food,2024-01-01,1100872,3
+Diageo,ORD-00290179_Diageo_Whisky Widget_PHD_Jan-June25,1938830,Alcohol,2025-01-01,1094227,3078
+Diageo,ORD-00290179_Diageo_Whisky_Widget_PHD_Jan-June25,1953536,Alcohol,2025-01-01,1094227,3078
+Barclays,ORD-00289617 _Direct_OMD_Barclays_ATV_RT_Q424_LD,1819663,Government,2024-01-01,1069457,19987
+ITV,ORD-00297090_BARTER ITV I'm A Celeb x Immediate Q4 2025,2171070,Supermarket,2025-01-01,1064663,14084
+Birds Eye,ORD-00298551_Birds Eye Peas - Zenith - March - April,2277873,Food,2026-01-01,1053175,203
+Disney+,Moana 2 2025,1902031,Entertainment,2025-01-01,1016177,17914
+Abarth,ORD-00295098_Abarth_600E_Q2_+_Q3_TG,2085940,Motoring,2025-01-01,1015452,11681
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,1001246,678
+Tesco,ORD-00290546 _BARTER Tesco Christmas 2024 Digital Campaign,1866821,Supermarket,2024-01-01,1000186,3575
+Morrisons,ORD-00292183_Morrisons 2025 partnership_Wavemaker_Feb-Oct25,1940739,Supermarket,2025-01-01,1000172,2415
+Morrisons,ORD-00292183_Morrisons 2025 partnership_Wavemaker_Feb-Oct25,1940739,Supermarket,2025-01-01,1000104,1303
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,1000086,1138
+Florette,ORD-00292672_Florette_Caratleeds_Partnership_May-July2025,1993798,Food,2025-01-01,1000037,756
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,1000026,1517
+NOW TV,PG_NOW - The Day of the Jackal. Nov Digi Campaign,1823205,Entertainment,2024-01-01,1000023,16276
+Kerrygold,ORD-00292017_Kerrygold_PHDManchester_partnership2025,1959016,Food,2025-01-01,1000019,282
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,1000010,328
+Sky,ORD-00296626 Sky Publishing campaign- The Iris Affair,2151577,Entertainment,2025-01-01,1000003,18584
+Princess Cruises ,ORD-00277435_Princess 24 partnership_7 STars_Dec-May,1525755,Travel,2024-01-01,1000001,33953
+Sky,ORD-00296626 Sky Publishing campaign- The Iris Affair,2151577,Entertainment,2025-01-01,1000000,962
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,999673,1059
+Morrisons,ORD-00292183_Morrisons 2025 partnership_Wavemaker_Feb-Oct25,1940739,Supermarket,2025-01-01,999270,23512
+Centrum,ORD-00291473_Centrum_Spark_Vitamins 2025,1896853,Health,2025-01-01,999113,11769
+The Walt Disney Company,PG_NatGeo_Zenith_Top_Gun_19th_September,2125006,Entertainment,2025-01-01,998021,0
+Tesco,ORD-00297187_Tesco Christmas 2025,2245164,Food,2025-01-01,995490,14926
+Tesco,ORD-00290546 _BARTER Tesco Christmas 2024 Digital Campaign,1866821,Supermarket,2024-01-01,995014,20300
+ITV,ORD-00297090_BARTER ITV I'm A Celeb x Immediate Q4 2025,2171070,Supermarket,2025-01-01,988415,16063
+Warner - Tom Kerridge,ORD-00287390_Warner_TomKerridgeShow_Sep,1775134,Entertainment,2024-01-01,985734,9234
+Audible,Audible_wavemaker_Comedy_July25,2054149,Entertainment,2025-01-01,983676,5221
+Visa,PG_Visa_Q4_2025_December&January,2221526,Retail,2026-01-01,979316,8494
+BSskyb,ORD-00295733_Sky X Netflix_Zenith_Partnership_September,2125057,Entertainment,2025-01-01,973464,8490
+E.ON,ORD-00291553_E.On Next 2025,1895637,Tech,2025-01-01,952601,9179
+E.ON,ORD-00291553_E.On Next 2025,1895637,Tech,2025-01-01,952406,10178
+Princess Cruises ,ORD-00277435_Princess 24 partnership_7 STars_Dec-May,1525755,Travel,2024-01-01,950047,21498
+Winalot,Winalot 2024_OpenMind_WPP,1647224,Pets,2024-01-01,950003,330
+Princess Cruises ,ORD-00277435_Princess 24 partnership_7 STars_Dec-May,1525755,Travel,2024-01-01,947911,15683
+Hendricks ,ORD-00294564_Hendrick's Display - June/July 2025,2048762,Alcohol,2025-01-01,945158,1680
+Lidl,ORD-00288216_Direct_Lidl AppleandPears_sept24_LD,1768361,Supermarket,2024-01-01,943424,11447
+Aldi,ORD-00295386_Direct_Aldi_August_Digi_2025,2080311,Supermarket,2025-01-01,929403,22912
+Twix,PG_Twixmas_Amex_Dec 2025_Immediate,2206036,Food,2025-01-01,926850,21307
+Specsavers ,PG_Specs_MGOMD_OwnedandRun_Oct-Dec_LD,1869417,Health,2024-01-01,925886,17553
+Nestle Purina,PG_Nestle_Openmind_Purina Gourmet_05/05/25-29/06/25_RT,2019876,Pets,2025-01-01,923094,0
+Post Office,ORD-00291044_PostOfficeSavings_TheStoryLab_Sept24-Mar25,1904969,Government,2025-01-01,914242,1927
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,906186,167
+Lidl,ORD-00288216_Direct_Lidl AppleandPears_sept24_LD (Correct),1761875,Supermarket,2024-01-01,905713,10982
+BSskyb,ORD-00295733_Sky X Netflix_Zenith_Partnership_September,2125057,Entertainment,2025-01-01,904315,7042
+Tesco,ORD-00290546 _BARTER Tesco Christmas 2024 Digital Campaign,1866821,Supermarket,2024-01-01,901033,9458
+Hendricks ,ORD-00294564_Hendrick's Display - June/July 2025,2048762,Alcohol,2025-01-01,895153,19951
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,894170,12662
+Merchant Gourmet,ORD-00291231_Merchant Gourmet_Yonder_Good Food_January 2025,1895723,Food,2025-01-01,884625,1511
+Eco Manure,"ORD-00293368/ORD-00293759_Eco Manure_HP, Solus, Social, Comp & Display",2048752,Gardening,2025-01-01,881720,1636
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,880255,9581
+Nutracheck,Nutracheck,1856812,On-Demand,2024-01-01,878452,468
+Sky,ORD-00296626 Sky Publishing campaign- The Iris Affair,2151577,Entertainment,2025-01-01,872125,7399
+Apple,ORD-00288525_Direct_Apple_MGOMD_RT_Wolfs_Sept_LD,1768307,Entertainment,2024-01-01,868596,7722
+Aviva,PG_Aviva_Health_RON_20/05,2053912,Health,2025-01-01,868093,8920
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,850038,8960
+Apple,ORD-00286576_Direct_Apple_MGOMD_RT_TheInstigators_LD,1725540,Entertainment,2024-01-01,837993,7533
+Kerrygold,ORD-00290861 Kerrygold_PHD Man_Q4 2024,1869178,Food,2024-01-01,833573,906
+Turtle Wax,PG_Turtle WaxUK_26PMX_SkinMMA_TG_JunAug25,2047684,Motoring,2025-01-01,833459,391
+Sainsburys,ORD-00293866_Sainsbury's Q2 TTD Campaign 2025,2003631,Supermarket,2025-01-01,833334,16156
+Disney+,Moana 2 2025,1902031,Entertainment,2025-01-01,821671,9352
+Nestle Purina,PG_Nestle_Openmind_Purina Gourmet_05/05/25-29/06/25_RT,2019876,Pets,2025-01-01,818421,314
+Aldi,PG_Aldi_December_Olive_GoodFood,2245377,Supermarket,2025-01-01,804602,11009
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,800020,14262
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,800005,17953
+Florette,ORD-00292672_Florette_Caratleeds_Partnership_May-July2025,1993798,Food,2025-01-01,799919,17282
+Apple,ORD-00290414_Direct_Apple_Blitz RT_Nov-Dec-LD,1869361,Entertainment,2024-01-01,793403,7240
+Sainsburys,ORD-00294588_Sainsbury's x Good Food TTD P2 June-August,2045562,Supermarket,2025-01-01,789811,15836
+Tesco,ORD-00296514_Tesco Food Is Everything Oct 2025,2167250,Supermarket,2025-01-01,778560,7467
+Carte D'Or,ORD-00297006 Direct_Digi_Carte D'Or_Q4 2025,2174656,Food,2025-01-01,778007,4726
+Alpen,ORD-00277683_Alpen_GetMeMedia_Nov-Sept,1601248,Food,2024-01-01,774093,651
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,770563,1180
+Fortnum and Mason, PG_F&M Xmas25_26PMX_IMAudHigh Impact_GF_V2,2175953,Retail,2025-01-01,769735,8422
+Aldi,Aldi_Christmas_25,2175479,Food,2025-01-01,768634,297
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,768634,297
+HBO Max,ORD-00299155_HBOMAX_Radio_Times_2026,2293143,Entertainment,2026-01-01,760562,8028
+Diageo,ORD-00290179_Diageo_Whisky_Widget_PHD_Jan-June25,1953536,Alcohol,2025-01-01,759912,39
+Diageo,ORD-00290179_Diageo_Whisky Widget_PHD_Jan-June25,1938830,Alcohol,2025-01-01,759912,39
+Waitrose,ORD-00290352_Direct_Waitrose_MGOMD_Christmas_Masthead_November/Dec_24_LD,1908287,Supermarket,2024-01-01,755584,11010
+Waitrose,PG_Waitrose_MGOMD_Christmas_November/Dec_24_LD,1854565,Supermarket,2024-01-01,755584,11009
+Carte D'Or,ORD-00297006 Direct_Digi_Carte D'Or_Q4 2025,2174656,Food,2025-01-01,750054,560
+NOW TV,PG_NOW - The Day of the Jackal. Nov Digi Campaign,1823205,Entertainment,2024-01-01,750006,7793
+Princess Cruises ,ORD-00277435_Princess 24 partnership_7 STars_Dec-May,1525755,Travel,2024-01-01,750005,1067
+Finish,ORD-00285482 & ORD-00285447_Finish_Zenith_Q3,1696536,Food,2024-01-01,750001,324
+Princess Cruises ,ORD-00277435_Princess 24 partnership_7 STars_Dec-May,1525755,Travel,2024-01-01,750000,17203
+Diageo,Diageo_JohnnieWalkerBlack_Sep-Dec (Native),1817891,Alcohol,2024-01-01,744475,10236
+Waitrose,PG_Waitrose_MGOMD_Christmas_November/Dec_24_LD,1854565,Supermarket,2024-01-01,740587,13856
+Lidl,ORD-00292527_Direct_Lidl_Fresh_FebMarch25_LD,1981602,Food,2025-01-01,738154,6646
+Morrisons,ORD-00283323_Morrisons_Wavemaker_May-Nov 2024 partnership,1640453,Supermarket,2024-01-01,728913,4492
+Abarth,ORD-00293456_Abarth 600E_Q2_TG,1974081,Motoring,2025-01-01,715797,6585
+Renault,ORD-00296021_Direct_Renault_MGOMD_R4_TG_Sept_LD,2130221,Motoring,2025-01-01,715613,6983
+Kerrygold,ORD-00290861 Kerrygold_PHD Man_Q4 2024,1869178,Food,2024-01-01,714309,23527
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,713761,10353
+Visit Orlando,ORD-00295890 Visit Orlando Display,2161910,Travel,2025-01-01,709586,9047
+Renault,ORD-00296433_Renault_MGOMD_Renault 4_September-October25,2162513,Motoring,2025-01-01,705777,979
+Carte D'Or,PG_Digi_Carte D'Or_Q2,1616515,Food,2024-01-01,703844,7010
+Warner Brothers,ORD-00292957 Warner_MinecraftMovie_Mar-Apr,1946107,Entertainment,2025-01-01,702517,2023
+Carte D'Or,PG_Digi_Carte D'Or_Q2,1616515,Food,2024-01-01,701779,7193
+Spinnaker London,ORD-00291496_European Mushroom_DMPU_MB_GF_JAN'25,1884937,Food,2025-01-01,700094,247
+shell,ORD-00294734_Shell F1 x Top Gear 2025,2071034,On-Demand,2025-01-01,700018,1135
+Princess Cruises ,ORD-00277435_Princess 24 partnership_7 STars_Dec-May,1525755,Travel,2024-01-01,700012,1041
+European Mushrooms,ORD-00291496_European Mushroom_DMPU_MB_GF_JAN'25,1901949,Food,2025-01-01,700006,241
+Disney+,PG_Disney_Inside Out 2 D+ Campaign Oct 24,1770302,On-Demand,2024-01-01,699207,11233
+Carte D'Or,ORD-00297006 Direct_Digi_Carte D'Or_Q4 2025,2174656,Food,2025-01-01,697108,3336
+Kerrygold,ORD-00292017_Kerrygold_PHDManchester_partnership2025,1959016,Food,2025-01-01,697073,6404
+Inspired Villages Group Limited,ORD-00284044_Inspired Villages Soap Awards,1701686,Entertainment,2024-01-01,694448,1149
+Inspired Villages Group Limited,ORD-00284044_Inspired Villages Soap Awards,1701686,Entertainment,2024-01-01,694444,615
+Carte D'Or,ORD-00297006 Direct_Digi_Carte D'Or_Q4 2025,2174656,Food,2025-01-01,691290,1049
+Dacia,ORD-00295503_Direct_Dacia_MGOMD_TG_Aug_LD,2089459,Motoring,2025-01-01,690570,7134
+ITV,ORD-00297090_BARTER ITV I'm A Celeb x Immediate Q4 2025,2171070,Supermarket,2025-01-01,689875,3813
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,686369,7091
+Sainsburys,ORD-00294588_Sainsbury's x Good Food TTD P2 June-August,2045562,Supermarket,2025-01-01,685767,8399
+Birds Eye,ORD-00298551_Birds Eye Peas - Zenith - March - April,2277873,Food,2026-01-01,683564,148
+Beko,ORD-00293616_Beko_RunningTotal_GFKitchenvalue2025,1973988,Tech,2025-01-01,682792,0
+Jaguar Landrover,ORD-00295165_Direct _JLR_He&S_Multibrand_Q3-2026_LD,2074264,Motoring,2025-01-01,674278,2606
+Holiday Property Bond,"HPB x RT, OLI, GF, GW report - ORD-00293737",2055336,Travel,2025-01-01,673125,8112
+The Walt Disney Company,PG_Disney+_Amanda Knox_Video RT,2249392,Entertainment,2025-01-01,672664,7896
+The Walt Disney Company,PG_Disney+_Amanda Knox_Video RT,2249392,Entertainment,2025-01-01,670521,7937
+Tesco,ORD-00288310_Tesco Whoosh - September 2024 Campaign,1773458,Supermarket,2024-01-01,669885,12000
+Visa, PG_Visa_Q4_2025_Decembe,2216277,Retail,2025-01-01,669881,5657
+Visa,PG_Visa_Q4_2025_December&January,2221526,Retail,2025-01-01,669858,5657
+Marks & Spencer,ORD-00290864 Direct-M&S-Mindshare- Xmas digital - 4th November - 28th November,1876342,Food,2024-01-01,666725,7215
+Marks & Spencer,ORD-00297227_Direct_Digi_M&S_TomKerridgeKitchenware_Q42025,2217707,Supermarket,2025-01-01,666661,3695
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,666656,16313
+Alpine,ORD-00293691_Direct_Alpine_MGOMD_A290_TG_April_LD,2013489,Motoring,2025-01-01,666620,247
+Alpine,ORD-00293691_Direct_Alpine_MGOMD_A290_TG_April_LD,2013489,Motoring,2025-01-01,666564,299
+Warner - Tom Kerridge,ORD-00287390_Warner_TomKerridgeShow_Sep,1775134,Entertainment,2024-01-01,663782,10585
+Waitrose,PG_Waitrose_MGOMD_Summer_LD,2038961,Supermarket,2025-01-01,658909,15413
+Beko,ORD-00293616_Beko_RunningTotal_GFKitchenvalue2025,1973988,Tech,2025-01-01,657726,0
+National Geographic,PG_Nat_Geo_Publicis_Tsunami_Race Against_Time_November,1896920,Entertainment,2024-01-01,655649,0
+The Walt Disney Company,PG_Disney_Elio_June_RON_02/06/25,2040079,Entertainment,2025-01-01,654309,14739
+shell,ORD-00286771_Shell x Top Gear VPower,1733425,Motoring,2024-01-01,653288,1179
+Disney+,PG_Disney+_Zenith_The Bear S3 2024,1671677,Entertainment,2024-01-01,651447,9134
+Apple,ORD-00291464_Direct_Apple_Severance2 RT_Jan_LD,1890070,Entertainment,2025-01-01,650027,2125
+E.ON,ORD-00291553_E.On Next 2025,1895637,Tech,2025-01-01,645297,11462
+E.ON,ORD-00291553_E.On Next 2025,1895637,Tech,2025-01-01,645010,11384
+Nestle - Maggi, PG_Nestle_Maggi_ 10/10-31/12_,1823799,Food,2024-01-01,644436,5054
+Apple,ORD-00295569_Direct_Apple_SlowHorsesS5_ RT_Sept_LD,2125041,Entertainment,2025-01-01,641390,7038
+Fortum & Mason,PG_Fortnum&Mason_Xmas_GF_Adnami Skin+MMA_Nov-Dec24,1837413,Food,2024-01-01,638016,7133
+Diageo,ORD-00282260_ Diageo_Cocktail Widget_PHD_MarJun24,1604691,Alcohol,2024-01-01,637602,1928
+Diageo,ORD-00282260_ Diageo_Cocktail Widget_PHD_MarJun24,1604691,Alcohol,2024-01-01,632144,179
+Apple,ORD-00291463_Direct_Apple_PrimeTarget_ RT_Jan_LD,1894480,Entertainment,2025-01-01,630672,9151
+Florette,ORD-00292672_Florette_Caratleeds_Partnership_May-July2025,1993798,Food,2025-01-01,628757,13564
+Arla Lurpak,PG_Arla_LurpakPlant_Sept24,1789288,Food,2024-01-01,625223,1214
+Saga,ORD-00284736 Saga Holiday_Dentsu_Skin+Standard_Jul24,1664796,Travel,2024-01-01,624149,3956
+Finish,ORD-00285482 & ORD-00285447_Finish_Zenith_Q3,1696536,Food,2024-01-01,618542,2962
+Abbott,ORD-00287639_Abbott_Freestyle Libre Healthy Diet_2024,1805926,Food,2024-01-01,616992,728
+Abbott,ORD-00287639_Abbott_Freestyle Libre Healthy Diet_2024,1805926,Food,2024-01-01,616969,786
+TV5 Monde,ORD-00290347_TV5Monde November 2024,1869288,Entertainment,2024-01-01,616258,5908
+Kerrygold,ORD-00290861 Kerrygold_PHD Man_Q4 2024,1869178,Food,2024-01-01,615565,20670
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,614961,12704
+Post Office,ORD-00291044_PostOfficeSavings_TheStoryLab_Sept24-Mar25,1904969,Government,2025-01-01,614478,567
+Holland & Barrett,ORD-00291348_H&B P3 Nutrition_Skins&MMA_Jan 25,1879540,Health,2025-01-01,612906,8714
+Tesco,ORD-00293302_Tesco Easter - Digital Campaign,1973907,Supermarket,2025-01-01,612556,8632
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,611659,86
+Alfa Romeo,ORD-00294948_Direct_Alfa Romeo_Q3_2025,2086008,Motoring,2025-01-01,609988,861
+Cuprinol,ORD-00280426_Cuprinol_Q2 2024_Partnership_Mediahub,1580624,Health,2024-01-01,608609,7074
+BYD,ORD-00298895_BYD Lead Gen_Top Gear Direct_Q1 2026,2280867,Motoring,2026-01-01,600211,2209
+Holland & Barrett,ORD-00291348_H&B P3 Nutrition_Skins&MMA_Jan 25,1879540,Health,2025-01-01,599975,228
+Hyundai Motor (UK),ORD-00291653_Hyundai_Regional_Innocean_Q1_25,1895619,Motoring,2025-01-01,598492,6210
+Tesco,ORD-00290546 _BARTER Tesco Christmas 2024 Digital Campaign,1866821,Supermarket,2024-01-01,596842,616
+Soberano,ORD-00290571 Soberano Sherry_Alchemy Media_Q4 digi GF,1837199,Alcohol,2024-01-01,595253,5676
+The Crown Estate,ORD-00295181_TCE FOF 25_RunningTotal_IMAud&MMA_AugSept25,2080345,Food,2025-01-01,594330,5425
+Waitrose,ORD-00293374_Direct_Waitrose_MGOMD_Easter25_LD,1969303,Supermarket,2025-01-01,594124,229
+Waitrose,ORD-00293374_Direct_Waitrose_MGOMD_Easter25_LD,1969303,Supermarket,2025-01-01,593993,417
+Nutracheck,Nutracheck,1856812,On-Demand,2024-01-01,591139,305
+Post Office,ORD-00291044_PostOfficeSavings_TheStoryLab_Sept24-Mar25,1904969,Government,2025-01-01,591062,458
+ITV,ITV_EMX_Q4 24 Planning_Digital and Print ,1852125,Entertainment,2024-01-01,588304,0
+Disney+,PG_Disney+_Zenith_The Bear S3 2024,1671677,Entertainment,2024-01-01,585932,22916
+Castello,ORD-00297085_Arla_Castello_Xmas_value,2198169,Food,2025-01-01,581168,5897
+Ninja,Shark Ninja,1912836,Tech,2024-01-01,580748,15394
+Energizer,PG_Armor All_May-Jul '25_TG,2092794,Motoring,2025-01-01,580370,286
+Aviva,PG_Aviva_Health_RON_20/05,2053912,Health,2025-01-01,580139,12124
+Cuprinol,ORD-00280426_Cuprinol_Q2 2024_Partnership_Mediahub,1580624,Health,2024-01-01,580000,1389
+Post Office,ORD-00291044_PostOfficeSavings_TheStoryLab_Sept24-Mar25,1904969,Government,2025-01-01,579896,1201
+Apple,ORD-00288149+ORD-00287960 Apple Slow Horses x BFI,1770104,Entertainment,2024-01-01,579855,4166
+Gousto,ORD-00297780_Gousto_brandpartnership_26,2224957,Food,2025-01-01,579405,9142
+Post Office,ORD-00291044_PostOfficeSavings_TheStoryLab_Sept24-Mar25,1904969,Government,2025-01-01,578910,510
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,577769,23709
+Abarth,ORD-00295098_Abarth_600E_Q2_+_Q3_TG,2085940,Motoring,2025-01-01,577389,5681
+Wargaming Group Ltd,ORD-00278599_WarThunder_IM_Hist/RT_2024,1596290,Gaming,2024-01-01,576698,35268
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1962013,Motoring,2025-01-01,576640,805
+National Geographic,PG_Nat Geo: Megastructures_Dec 2024,1857117,Entertainment,2024-01-01,575623,5205
+Audible,Audible_wavemaker_Comedy_July25,2054149,Entertainment,2025-01-01,571784,695
+Castello,ORD-00297085_Arla_Castello_Xmas_value,2198169,Food,2025-01-01,569269,5954
+Pernod Ricard,PG_MGOMD_Pernod_Altos_June/July_LD,1713659,Alcohol,2024-01-01,566668,4799
+Pernod Ricard,PG_MGOMD_Pernod_Altos_June/July_LD,1713659,Alcohol,2024-01-01,566655,4627
+Kerrygold,ORD-00292017_Kerrygold_PHDManchester_partnership2025,1959016,Food,2025-01-01,565460,11981
+Lidl,ORD-00290345_Direct_Lidl_OMD_Christmas_24_LD,1876516,Supermarket,2024-01-01,564895,5217
+Itsu ,ORD-00287826_Direct - Itsu_Yonder_Summer Brief_Sept 2024,1748340,Food,2024-01-01,563316,5010
+National Geographic,PG_Nat Geo: Defending Europe_RT History Sep,1760336,Entertainment,2024-01-01,562761,7882
+Abbott,ORD-00295651 Abbott Freestyle Libre ,2193187,Food,2025-01-01,560236,5348
+Abbott,ORD-00295651 Abbott Freestyle Libre ,2193187,Food,2026-01-01,560206,4982
+Kerrygold,ORD-00299430_Kerrygold_PHD_GF_StPatricksDay_Skin&MMA_Mar25,2280231,Food,2026-01-01,557150,3897
+Disney+,PG_Disney+_Zenith_The Bear S3 2024,1671677,Entertainment,2024-01-01,557043,23357
+ITV,ITV_EMX_Q4 24 Planning_Digital and Print ,1852125,Entertainment,2024-01-01,555895,429
+Disney+,PG_Disney_Moana 2_Nov 2024,1827805,Entertainment,2024-01-01,554924,9950
+Gousto,ORD-00297780_Gousto_brandpartnership_26,2224957,Food,2025-01-01,551889,9832
+Marks & Spencer,ORD-00290864 Direct-M&S-Mindshare- Xmas digital - 4th November - 28th November,1876342,Food,2024-01-01,550274,404
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,550149,813
+Winalot,Winalot 2024_OpenMind_WPP,1647224,Pets,2024-01-01,550001,249
+Disney+,PG_Disney+_Zenith_The Stolen Girl_16 April - 4th May,1976741,Entertainment,2025-01-01,546928,5267
+Disney+,PG_Disney+_Zenith_The Stolen Girl_16 April - 4th May,1976741,Entertainment,2025-01-01,546023,6272
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,545461,4734
+Apple,ORD-00288149+ORD-00287960 Apple Slow Horses x BFI,1770104,Entertainment,2024-01-01,535006,5417
+Marks & Spencer,ORD-00290864 Direct-M&S-Mindshare- Xmas digital - 4th November - 28th November,1876342,Food,2024-01-01,533354,676
+National Geographic,PG_Nat_Geo_Publicis_Tsunami_Race Against_Time_November,1896920,Entertainment,2024-01-01,532499,3117
+Apple,PG_Apple_MGOMD_PresumedInnocent_Playstream_June_LD,1685584,Entertainment,2024-01-01,532319,458
+Renault,ORD-00292825 Direct_MGOMD_RenaultR5_TopGear_March_LD,1946202,Motoring,2025-01-01,530993,498
+Sainsburys,ORD-00293866_Sainsbury's Q2 TTD Campaign 2025,2003631,Supermarket,2025-01-01,530350,5776
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,526023,497
+HBO Max,ORD-00299155_HBOMAX_Radio_Times_2026,2293143,Entertainment,2026-01-01,524918,5712
+Sainsburys,PG_Sainsbury's_EMX_Weekly Moments_10/06-31/08_RT,1757525,Food,2024-01-01,524897,1459
+Sainsburys,PG_Sainsbury's_EMX_Weekly Moments_10/06-31/08_RT,1757525,Food,2024-01-01,524843,1607
+Visa,PG_Visa_Q4_2025_December&January,2221526,Retail,2026-01-01,524378,4526
+National Geographic,PG_Nat Geo_Zenith_David Blaine_24/03/25,1943612,Entertainment,2025-01-01,522216,0
+Apple,ORD-00291464_Direct_Apple_Severance2 RT_Jan_LD,1890070,Entertainment,2025-01-01,521720,10863
+Cuprinol,ORD-00280426_Cuprinol_Q2 2024_Partnership_Mediahub,1580624,Health,2024-01-01,520064,4886
+Apple,ORD-00288652_ORD-00288653 _ORD-00289004__ ORD-00289077Direc t_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1863128,Entertainment,2024-01-01,517244,253
+Apple,ORD-00289077Direct_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1792821,Entertainment,2024-01-01,517244,253
+Apple,"ORD-00292528,_ORD-00292529_Direct_Apple_MGOMD_RT_Marcomms_FebMarchLD",1965163,Entertainment,2025-01-01,517202,261
+Apple,ORD-00286576_Direct_Apple_MGOMD_RT_TheInstigators_LD,1725540,Entertainment,2024-01-01,515690,10372
+Sarson's,ORD-00288776_Sarsons Vinegar_Brewed for Food Burst 2_Food_Sep24,1789636,Food,2024-01-01,514364,3910
+Disney+,PG_Disney_Inside Out 2 EHV_Aug 24,1731379,Entertainment,2024-01-01,513673,8057
+Waitrose,PG_Waitrose_MGOMD_Christmas_November/Dec_24_LD,1854565,Supermarket,2024-01-01,513361,4577
+Diageo,ORD-00290180_Diageo_Christmas Cocktail Widget_PHD_Oct-Dec24,1888448,Alcohol,2024-01-01,512690,1086
+Itsu ,ORD-00287826_Direct - Itsu_Yonder_Summer Brief_Sept 2024,1748340,Food,2024-01-01,511414,382
+ITV,PG - ITV Red Eye S2 December 2025,2229998,Entertainment,2025-01-01,509333,11760
+National Geographic,PG_Nat Geo_Zenith_David Blaine_24/03/25,1943612,Entertainment,2025-01-01,507359,3173
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,504168,220
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,504165,382
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,504151,344
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,504143,410
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,504130,766
+Knorrr,ORD-00288397_Knorr Moments Digi 2024,1781575,Food,2024-01-01,503152,3860
+Morrisons,ORD-00292183_Morrisons 2025 partnership_Wavemaker_Feb-Oct25,1940739,Supermarket,2025-01-01,501264,6272
+BSskyb,ORD-00295733_Sky X Netflix_Zenith_Partnership_September,2125057,Entertainment,2025-01-01,500858,79
+Florette,ORD-00292672_Florette_Caratleeds_Partnership_May-July2025,1993798,Food,2025-01-01,500203,373
+Centrum,ORD-00291473_Centrum_Spark_Vitamins 2025,1896853,Health,2025-01-01,500058,3095
+ASDA,ASDA_Spark_AV,2226535,Supermarket,2025-01-01,500043,184
+ITV,ITV_EMX_Q4 24 Planning_Digital and Print ,1852125,Entertainment,2024-01-01,500036,6972
+Aldi,PG_Aldi Jan_Olive_GoodFood_CMT-Which-Promotion,1877160,Supermarket,2025-01-01,500024,3977
+Omada,ORD-00297056 Omoda Lead Gen_Top Gear Direct_Q4 2025,2228925,Motoring,2025-01-01,500020,257
+Aldi,PG_Aldi_December_Olive_GoodFood,2245377,Supermarket,2025-01-01,500019,9171
+Ocado,ORD-00285279_Ocado Made For Mums 2024,1798599,Parenting,2024-01-01,500014,4900
+Princess Cruises ,ORD-00277435_Princess 24 partnership_7 STars_Dec-May,1525755,Travel,2024-01-01,500006,7804
+Aldi,PG_Aldi_December_Olive_GoodFood,2245377,Supermarket,2025-01-01,500006,5958
+ASDA,ASDA_Spark_AV,2226535,Supermarket,2025-01-01,499996,135
+Lidl,ORD-00292527_Direct_Lidl_Fresh_FebMarch25_LD,1981602,Food,2025-01-01,499994,7587
+Centrum,ORD-00291473_Centrum_Spark_Vitamins 2025,1896853,Health,2025-01-01,499592,6069
+Turtle Wax,PG_Turtle WaxUK_26PMX_SkinMMA_TG_JunAug25,2047684,Motoring,2025-01-01,498378,4033
+Centrum,ORD-00291473_Centrum_Spark_Vitamins 2025,1896853,Health,2025-01-01,497463,4479
+BMW,ORD-00289484 BMW i5_Dentsu_Top Gear EV TO_Nov 24,1808769,Motoring,2024-01-01,496822,2307
+Aldi,ORD-00288560_Aldi Halloween Digi 2024,1787291,Food,2024-01-01,496394,5084
+Nintendo,ORD-00288651 Nintendo: Echoes of Wisdom,1814079,Gaming,2024-01-01,492661,4242
+Tesco,ORD-00293302_Tesco Easter - Digital Campaign,1973907,Supermarket,2025-01-01,489904,4595
+BYD,ORD-00298895_BYD Lead Gen_Top Gear Direct_Q1 2026,2280867,Motoring,2026-01-01,485590,515
+Sainsburys,PG_Sainsbury's_EMX_Weekly Moments_10/06-31/08_RT,1757525,Food,2024-01-01,484050,1273
+Apple,ORD-00289077Direct_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1792821,Entertainment,2024-01-01,481700,1968
+Apple,ORD-00288652_ORD-00288653 _ORD-00289004__ ORD-00289077Direc t_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1863128,Entertainment,2024-01-01,481700,1968
+Ninja,Shark Ninja,1912836,Tech,2024-01-01,480249,248
+Morrisons,ORD-00292183_Morrisons 2025 partnership_Wavemaker_Feb-Oct25,1940739,Supermarket,2025-01-01,478536,2062
+Jason's Sourdough,ORD-00295058/Jason's Sourdough_Alchemy Media,2117950,Food,2025-01-01,476205,4960
+Filippo Berrio,Connect_SF__Filippo Berio_ORD-00297235_Filippo_Berrio_Mediaplus_Xmas25SkinMMA_Dec25,2210671,Food,2025-01-01,476201,4479
+Sainsburys,PG_Sainsbury's_EMX_Weekly Moments_10/06-31/08_RT,1757525,Food,2024-01-01,470068,4864
+Sainsburys,PG_Sainsbury's_EMX_Weekly Moments_10/06-31/08_RT,1757525,Food,2024-01-01,470057,4815
+Wargaming Group Ltd,ORD-00278599_WarThunder_IM_Hist/RT_2024,1596290,Gaming,2024-01-01,468311,19883
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1982913,Motoring,2025-01-01,465329,739
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,463868,11322
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,462302,103
+Aldi,ORD-00294289&ORD-00294893_Direct_Aldi Summer Hub_2025,2023846,Supermarket,2025-01-01,458621,12892
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,457673,24262
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,457597,25677
+Morrisons,ORD-00292183_Morrisons 2025 partnership_Wavemaker_Feb-Oct25,1940739,Supermarket,2025-01-01,454286,2905
+Universal Pictures,PG_BridgetJones/UP_Social&Video_EMN_Feb25,1926357,Entertainment,2025-01-01,451801,552
+Aldi,PG_Aldi Jan_Olive_GoodFood_FWO,1877174,Supermarket,2025-01-01,450010,4983
+Damart, PG_Damart 2025_26PMX_MMA_OctNov25_Burst-2,2172501,Retail,2025-01-01,444466,6908
+Damart,PG_Damart 2025_26PMX_MMA_OctNov25,2134158,Retail,2025-01-01,444452,5950
+Apple,"ORD-00292528,_ORD-00292529_Direct_Apple_MGOMD_RT_Marcomms_FebMarchLD",1965163,Entertainment,2025-01-01,444443,2962
+National Theatre,ORD-00291639_National Theatre At Home Q1 Campaign,1936550,Entertainment,2025-01-01,442593,8240
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,437256,8852
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,435589,8794
+Nintendo,ORD-00288651 Nintendo: Echoes of Wisdom,1814079,Gaming,2024-01-01,435065,9157
+Sainsburys,PG_Sainsbury's_EMX_Weekly Moments_10/06-31/08_RT,1757525,Food,2024-01-01,433488,4041
+Alpine,ORD-00294937_Direct_Alpine_MGOMD_TG_Q3_LD,2085964,Motoring,2025-01-01,433010,5498
+Apple,ORD-00286876 _Direct_Apple_MGOMD_BadMonkey_Aug_LD,1721087,Entertainment,2024-01-01,431034,133
+Apple,ORD-00288149+ORD-00287960 Apple Slow Horses x BFI,1770104,Entertainment,2024-01-01,430164,3741
+Omada,ORD-00297056 Omoda Lead Gen_Top Gear Direct_Q4 2025,2228925,Motoring,2025-01-01,429146,289
+Apple,ORD-00289077Direct_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1792821,Entertainment,2024-01-01,428582,1493
+Apple,ORD-00288652_ORD-00288653 _ORD-00289004__ ORD-00289077Direc t_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1863128,Entertainment,2024-01-01,428582,1493
+Quickline Broadband,Quickline Broadband_ORD-00298403&ORD-00298567,2237189,Tech,2026-01-01,428492,3508
+The Crown Estate,PG_FOF24_Crown Estate Digital_GF Midscroll_Aug24,1722605,Food,2024-01-01,428445,2212
+Apple,"ORD-00292528,_ORD-00292529_Direct_Apple_MGOMD_RT_Marcomms_FebMarchLD",1965163,Entertainment,2025-01-01,427826,1591
+Disney+,PG_Digital_Disney_Zenith_InsideOut2MayJun-2024,1639286,Entertainment,2024-01-01,427514,7044
+Apple,ORD-00289207 _Direct_Apple_MGOMD_RT_Disclaimers_Oct_LD,1863561,Entertainment,2024-01-01,425963,177
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,425003,1392
+The Walt Disney Company,Order_PG_Disney_Zenith_Hoppers,2259041,Entertainment,2026-01-01,423090,7139
+Post Office,ORD-00291044_PostOfficeSavings_TheStoryLab_Sept24-Mar25,1904969,Government,2025-01-01,420723,337
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,420459,573
+BBC Good Food,ORD-00292020_Tesco Food 3.0 - Feb Campaign. Digital,1912811,Supermarket,2025-01-01,420439,4018
+BBC Good Food,ORD-00292020_Tesco Food 3.0 - Feb Campaign. Digital,1912811,Supermarket,2025-01-01,420385,4434
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,420310,424
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,420121,318
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,420061,375
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,420037,424
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,420034,366
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,420032,361
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,420025,363
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,420003,492
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,419983,496
+Ruth Strauss Foundation,ORD-00294982 RSF x Immediate 2025,2141293,Health,2025-01-01,417059,143
+Arla Lurpak,PG_Arla_LurpakPlant_Sept24,1789288,Food,2024-01-01,416936,3999
+Arla Lurpak,PG_Arla_LurpakPlant_Sept24,1789288,Food,2024-01-01,416871,4483
+Aldi,PG_Aldi_Sept_Oct_Olive_GoodFood,2230444,Supermarket,2025-01-01,416675,118
+Tesco,ORD-00296514_Tesco Food Is Everything Oct 2025,2167250,Supermarket,2025-01-01,415326,8376
+Gousto,ORD-00297780_Gousto_brandpartnership_26,2224957,Food,2025-01-01,411101,4890
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,409697,8810
+ITV,PG - ITV Red Eye S2 December 2025,2229998,Entertainment,2025-01-01,405504,2547
+Renault,ORD-00292825 Direct_MGOMD_RenaultR5_TopGear_March_LD,1946202,Motoring,2025-01-01,404815,603
+Kerrygold,ORD-00299430_Kerrygold_PHD_GF_StPatricksDay_Skin&MMA_Mar25,2280231,Food,2026-01-01,403994,39
+Energizer,PG_Armor All_May-Jul '25_TG,2092794,Motoring,2025-01-01,403414,471
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,400048,1682
+Tesco,ORD-00293302_Tesco Easter - Digital Campaign,1973907,Supermarket,2025-01-01,400018,1330
+Sky,ORD-00291224_sky screen test Lockerbie,1887190,Entertainment,2024-01-01,400009,6094
+Asda,ORD-00290869 Direct - Asda_Spark_Christmas 2024,1870866,Food,2024-01-01,400006,7452
+Apple,ORD-00291463_Direct_Apple_PrimeTarget_ RT_Jan_LD,1894480,Entertainment,2025-01-01,400002,8863
+Winalot,Winalot 2024_OpenMind_WPP,1647224,Pets,2024-01-01,400000,345
+Alpine,ORD-00293691_Direct_Alpine_MGOMD_A290_TG_April_LD,2013489,Motoring,2025-01-01,399975,184
+Waitrose,PG_Waitrose_MGOMD_No1_Oct_LD,2139412,Supermarket,2025-01-01,398605,3572
+ITV,ITV_EMX_Q4 24 Planning_Digital and Print ,1852125,Entertainment,2024-01-01,393061,339
+ITV,ITV_EMX_Q4 24 Planning_Digital and Print ,1852125,Entertainment,2024-01-01,393007,563
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,388853,197
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,388849,421
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,388837,370
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,388816,545
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,388814,1268
+Jaguar Landrover,ORD-00295165_Direct _JLR_He&S_Multibrand_Q3-2026_LD,2074264,Motoring,2025-01-01,388428,195
+Jaguar Landrover,ORD-00295165_Direct _JLR_He&S_Multibrand_Q3-2026_LD,2074264,Motoring,2025-01-01,387691,606
+Lidl,ORD-00290345_Direct_Lidl_OMD_Christmas_24_LD,1876516,Supermarket,2024-01-01,387098,5440
+Gousto,ORD-00297780_Gousto_brandpartnership_26,2224957,Food,2025-01-01,386265,5846
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,385930,177
+Aldi,ORD-00294289&ORD-00294893_Direct_Aldi Summer Hub_2025,2023846,Supermarket,2025-01-01,383720,5735
+Finish,ORD-00285482 & ORD-00285447_Finish_Zenith_Q3,1696536,Food,2024-01-01,381463,1890
+Peugeot,ORD-00294321_Direct_Peugeot e3008_Q2_2025,2030170,Motoring,2025-01-01,381026,4713
+Quickline Broadband,Quickline Broadband_ORD-00298403&ORD-00298567,2237189,Tech,2026-01-01,380865,2900
+Apple,PG_Apple_MGOMD_PresumedInnocent_Playstream_June_LD,1685584,Entertainment,2024-01-01,380221,377
+Cuprinol,ORD-00280426_Cuprinol_Q2 2024_Partnership_Mediahub,1580624,Health,2024-01-01,380001,152
+Ninja,Shark Ninja,1912836,Tech,2024-01-01,378552,757
+Carte D'Or,PG_Digi_Carte D'Or_Q2,1616515,Food,2024-01-01,378205,3734
+Rowse,ORD-00287032 Rowse Summer_UM_2024,1744858,Food,2024-01-01,377905,155
+Miller & Carter,PG_Miller&Carter_26PMX_Skin&MMA_Sept_Oct_25,2109099,Food,2025-01-01,377792,4799
+Kerrygold,ORD-00290861 Kerrygold_PHD Man_Q4 2024,1869178,Food,2024-01-01,377423,6495
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,376683,163
+Knorrr,ORD-00288397_Knorr Moments Digi 2024,1781575,Food,2024-01-01,376008,4090
+Apple,ORD-00290414_Direct_Apple_Blitz RT_Nov-Dec-LD,1869361,Entertainment,2024-01-01,375031,7513
+Sarson's,ORD-00288776_Sarsons Vinegar_Brewed for Food Burst 2_Food_Sep24,1789636,Food,2024-01-01,375022,3371
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,373713,170
+Carte D'Or,PG_Digi_Carte D'Or_Q2,1616515,Food,2024-01-01,372863,3959
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,372791,152
+Sainsburys,PG_Sainsbury's_EMX_Weekly Moments_10/06-31/08_RT,1757525,Food,2024-01-01,372691,5160
+Sainsburys,PG_Sainsbury's_EMX_Weekly Moments_10/06-31/08_RT,1757525,Food,2024-01-01,372638,4288
+Apple,Direc t_Apple_MGOMD_RT_Marcomms_Sept_LD,1760160,Entertainment,2024-01-01,371440,1210
+Apple,ORD-00288652_ORD-00288653 _ORD-00289004__ ORD-00289077Direc t_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1863128,Entertainment,2024-01-01,371440,1210
+Apple,ORD-00289077Direct_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1792821,Entertainment,2024-01-01,371440,1210
+NOW TV,PG_NOW - The Day of the Jackal. Nov Digi Campaign,1823205,Entertainment,2024-01-01,370277,6154
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,369171,281
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,368889,568
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,368888,2753
+Abarth,ORD-00293456_Abarth 600E_Q2_TG,1974081,Motoring,2025-01-01,367110,1048
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,366427,695
+E.ON,ORD-00291553_E.On Next 2025,1895637,Tech,2025-01-01,357969,756
+E.ON,ORD-00291553_E.On Next 2025,1895637,Tech,2025-01-01,357954,812
+Immediate Media,Amazon XCM - Eclipse Takeover. 20/11/25,2187664,Retail,2025-01-01,357644,305
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,357188,60
+Apple,ORD-00286876 _Direct_Apple_MGOMD_BadMonkey_Aug_LD,1721087,Entertainment,2024-01-01,357169,3422
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,357165,284
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,357165,303
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,357163,593
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,357162,758
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,357157,22
+bet365,ORD-00278321 _bet365 H1 2024,1524821,Gambling,2024-01-01,357142,0
+Apple,ORD-00295569_Direct_Apple_SlowHorsesS5_ RT_Sept_LD,2125041,Entertainment,2025-01-01,356783,1220
+Primula,ORD-00282426_Primula_Fortitude_2024 food print digi,1678979,Food,2024-01-01,354835,3356
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,351546,3596
+Disney+,PG_Disney+_Zenith_The Stolen Girl_16 April - 4th May,1976741,Entertainment,2025-01-01,350844,6708
+Webb,ORD-00291352_Webb_2025 campaign,1983275,Gardening,2025-01-01,350184,8909
+Webb,ORD-00291352_Webb_2025 campaign,1959076,Gardening,2025-01-01,350184,8909
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,350111,8609
+Apple,ORD-00291464_Direct_Apple_Severance2 RT_Jan_LD,1890070,Entertainment,2025-01-01,350034,0
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,349999,3025
+Winalot,Winalot 2024_OpenMind_WPP,1647224,Pets,2024-01-01,349705,98
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,345197,33
+Apple,Direc t_Apple_MGOMD_RT_Marcomms_Sept_LD,1760160,Entertainment,2024-01-01,344835,130
+Apple,ORD-00288652_ORD-00288653 _ORD-00289004__ ORD-00289077Direc t_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1863128,Entertainment,2024-01-01,344835,130
+Apple,ORD-00289077Direct_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1792821,Entertainment,2024-01-01,344835,130
+Apple,ORD-00290229/ORD-00290227Direct_Apple_MGOMD_RT_BadSisters_Nov_LD,1869269,Entertainment,2024-01-01,344831,141
+Apple,"ORD-00292528,_ORD-00292529_Direct_Apple_MGOMD_RT_Marcomms_FebMarchLD",1965163,Entertainment,2025-01-01,344815,1384
+National Theatre,ORD-00291639_National Theatre At Home Q1 Campaign,1914407,Entertainment,2025-01-01,343703,6456
+Sainsburys,PG_Sainsbury's_EMX_Weekly Moments_10/06-31/08_RT,1757525,Food,2024-01-01,343548,3906
+Disney+,PG_Disney+_Zenith_The Stolen Girl_16 April - 4th May,1976741,Entertainment,2025-01-01,343476,5465
+Age of Elegance,ORD-00293188_Age of Elegance - March - June 2025,2020105,Entertainment,2025-01-01,341697,114
+Age of Elegance,ORD-00293188_Age of Elegance - March - June 2025,2020105,Entertainment,2025-01-01,341674,178
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,339422,19551
+Disney+,PG_Disney+_Zenith_The Stolen Girl_16 April - 4th May,1976741,Entertainment,2025-01-01,339306,207
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,336702,985
+Apple,ORD-00288149+ORD-00287960 Apple Slow Horses x BFI,1770104,Entertainment,2024-01-01,336654,2966
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,335095,20196
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,335093,625
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,335040,672
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,335032,19050
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,335030,633
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,335025,793
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,335016,603
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,335005,21153
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,335000,507
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,334923,19092
+Nutracheck,Nutracheck,1856812,On-Demand,2024-01-01,334838,221
+Turtle Wax,PG_Turtle WaxUK_26PMX_SkinMMA_TG_JunAug25,2047684,Motoring,2025-01-01,334778,842
+The Walt Disney Company,PG_Disney_Elio_June_RON_02/06/25,2040079,Entertainment,2025-01-01,334693,6798
+Apple,ORD-00290414_Direct_Apple_Blitz RT_Nov-Dec-LD,1869361,Entertainment,2024-01-01,334666,3049
+Disney+,PG_Disney_Moana 2_Nov 2024,1827805,Entertainment,2024-01-01,334342,6653
+Apple,ORD-00288149+ORD-00287960 Apple Slow Horses x BFI,1770104,Entertainment,2024-01-01,333770,2676
+ITV,ITV_EMX_Q4 24 Planning_Digital and Print ,1852125,Entertainment,2024-01-01,333396,1397
+Pernod Ricard,PG_MGOMD_Pernod_Altos_June/July_LD,1713659,Alcohol,2024-01-01,333347,2701
+Pernod Ricard,PG_MGOMD_Pernod_Altos_June/July_LD,1713659,Alcohol,2024-01-01,333336,2590
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,332687,18760
+Tesco,ORD-00290546 _BARTER Tesco Christmas 2024 Digital Campaign,1866821,Supermarket,2024-01-01,331803,6094
+Apple,ORD-00299337_Direct_Apple_Monarch__RT_Feb26,2264992,Entertainment,2026-01-01,331741,3838
+Arla,ORD-00293208_Arla_Lurpak_Easter_25_Value,1983591,Food,2025-01-01,331562,1057
+BBC Good Food,ORD-00292020_Tesco Food 3.0 - Feb Campaign. Digital,1912811,Supermarket,2025-01-01,331173,5816
+BBC Good Food,ORD-00292020_Tesco Food 3.0 - Feb Campaign. Digital,1912811,Supermarket,2025-01-01,331124,6280
+National Geographic,PG_Nat_Geo_Publicis_Tsunami_Race Against_Time_November,1896920,Entertainment,2024-01-01,328560,3671
+Mattel UK,ORD-00295966_Mattel_UM_Mattel Hot Wheels_15.09,2139285,Entertainment,2025-01-01,328204,3598
+Disney+,PG_Disney+_Zenith_The Stolen Girl_16 April - 4th May,1976741,Entertainment,2025-01-01,327901,683
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,324808,13940
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,324178,328
+My Expert Midwife,ORD-00294341_Direct_MyexpertMidwife_Alchemy_Digi MFM,2062059,Parenting,2025-01-01,322719,6403
+Filippo Berrio,Connect_SF__Filippo Berio_ORD-00297235_Filippo_Berrio_Mediaplus_Xmas25SkinMMA_Dec25,2210671,Food,2025-01-01,322595,6035
+Primula,ORD-00292203_Primula_Alchemy Media_Dec 25 Digi,2195080,Food,2025-01-01,322595,3551
+Primula,ORD-00288988_Primula_Alchemy Media_Print Digi food festive,1871565,Food,2024-01-01,322594,3987
+Primula,ORD-00292202_Primula_Alchemy Media_April 25 Digi,1971007,Food,2025-01-01,322585,3729
+Primula - Easter,ORD-00292202_Primula_Alchemy Media_April 25 Digi,1981615,Food,2025-01-01,322571,3729
+Winalot,Winalot 2024_OpenMind_WPP,1647224,Pets,2024-01-01,322562,207
+Jason's Sourdough,ORD-00295058/Jason's Sourdough_Alchemy Media,2117950,Food,2025-01-01,322520,6318
+American Pistachio,ORD-00293270/ORD-00293326_American Pistachio_Summer2025_Print_Digi_GF_GW,2005736,Food,2025-01-01,320090,1523
+Apple,ORD-00290658/ORD-00290661_Direct_Apple_Iphone14Pro RT_LPTO_Nov-Dec-LD,1869545,Entertainment,2024-01-01,320029,1171
+Grana Padano,ORD-00290516_Grana_Padano_Xmas_GF_24,1878439,Food,2024-01-01,318002,1145
+Birds Eye,ORD-00298551_Birds Eye Peas - Zenith - March - April,2277873,Food,2026-01-01,317988,201
+Birds Eye,ORD-00298551_Birds Eye Peas - Zenith - March - April,2277873,Food,2026-01-01,317951,104
+Apple,ORD-00289077Direct_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1792821,Entertainment,2024-01-01,317925,1594
+Apple,ORD-00288652_ORD-00288653 _ORD-00289004__ ORD-00289077Direc t_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1863128,Entertainment,2024-01-01,317925,1594
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,315850,15277
+Miller & Carter,PG_Miller&Carter_26PMX_Skin&MMA_Sept_Oct_25,2109099,Food,2025-01-01,314599,6514
+Apple,ORD-00293816_Direct_MGOMD_Apple_FountainOfYouth_ RT_May_LD,2009825,Entertainment,2025-01-01,312291,3031
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,312142,8713
+Kerrygold,ORD-00299430_Kerrygold_PHD_GF_StPatricksDay_Skin&MMA_Mar25,2280231,Food,2026-01-01,310000,644
+Alpen,ORD-00277683_Alpen_GetMeMedia_Nov-Sept,1601248,Food,2024-01-01,309617,5308
+E.ON,ORD-00291553_E.On Next 2025,1895637,Tech,2025-01-01,308819,124
+E.ON,ORD-00291553_E.On Next 2025,1895637,Tech,2025-01-01,308740,202
+Warner Leisure,ORD-00278268 & ORD-00278274_Warner Leisure Hotels-Q4 2023 / Q1-2 2024,1510991,Travel,2024-01-01,307736,1920
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,305440,12908
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,303573,189
+Abbott,ORD-00287639_Abbott_Freestyle Libre Healthy Diet_2024,1805926,Food,2024-01-01,303025,8183
+Sainsburys,ORD-00293866_Sainsbury's Q2 TTD Campaign 2025,2003631,Supermarket,2025-01-01,303009,5569
+Barretine Spring + Summer GW,ORD-00291503_Barretine Digital 2025_ 1.04 - 29.06_GW,1983385,Gardening,2025-01-01,303000,3634
+Disney+,PG_Digital_Disney_Zenith_InsideOut2MayJun-2024,1639286,Entertainment,2024-01-01,301772,4301
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,300240,455
+Disney+,PG_Disney+_Zenith_The Bear S3 2024,1671677,Entertainment,2024-01-01,300175,128
+Disney+,PG_Disney_Inside Out 2 EHV_Aug 24,1731379,Entertainment,2024-01-01,300091,136
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,300039,608
+Itsu ,ORD-00287826_Direct - Itsu_Yonder_Summer Brief_Sept 2024,1748340,Food,2024-01-01,300014,1765
+Inspired Villages Group Limited,ORD-00284044_Inspired Villages Soap Awards,1701686,Entertainment,2024-01-01,300011,4689
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,300010,5473
+Apple,ORD-00292815/ORD-00292816_Direct_Apple_YourFriendsandNeighbours_ RT_April_LD,1980492,Entertainment,2025-01-01,300010,74
+Aldi,PG_Aldi_Valentines Day Feb,1907210,Food,2025-01-01,300006,3159
+TUI,ORD-00288923_TUI_Lanzarote Digi campaign - October 24,1794257,Travel,2024-01-01,299995,544
+Princess Cruises ,ORD-00277435_Princess 24 partnership_7 STars_Dec-May,1525755,Travel,2024-01-01,299991,226
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,299987,579
+Great Rail Journeys,ORD-00291417_GRJ_IMA_GW Q1 print digi,1909421,Travel,2025-01-01,299920,209
+Beko,ORD-00293616_Beko_RunningTotal_GFKitchenvalue2025,1973988,Tech,2025-01-01,299906,1016
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,299174,17495
+Carte D'Or,ORD-00297006 Direct_Digi_Carte D'Or_Q4 2025,2174656,Food,2025-01-01,299116,568
+Hyundai Motor (UK),ORD-00291653_Hyundai_Regional_Innocean_Q1_25,1895619,Motoring,2025-01-01,298252,2514
+Renault,ORD-00298920/ORD-00298921_Direct_Alpine_MGOMD_TG_Q1_EC,2256697,Motoring,2026-01-01,298051,116
+Alpine,ORD-00294937_Direct_Alpine_MGOMD_TG_Q3_LD,2085964,Motoring,2025-01-01,297203,402
+Alpine,ORD-00294937_Direct_Alpine_MGOMD_TG_Q3_LD,2085964,Motoring,2025-01-01,297011,57
+National Geographic,PG_Nat Geo_Zenith_David Blaine_24/03/25,1943612,Entertainment,2025-01-01,296300,254
+Finish,ORD-00285482 & ORD-00285447_Finish_Zenith_Q3,1696536,Food,2024-01-01,294625,25
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,292562,518
+National Geographic,PG_Nat Geo_Zenith_David Blaine_24/03/25,1943612,Entertainment,2025-01-01,292073,5613
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,290128,473
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,289269,1210
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,289268,1427
+Fortum & Mason,PG_Fortnum&Mason_Xmas_GF_Adnami Skin+MMA_Nov-Dec24,1837413,Food,2024-01-01,287589,4889
+Superdrug,ORD-00298203_Direct_Digi_Superdrug_GoodFood_Jan2026,2232195,Health,2026-01-01,286519,4532
+Apple,"ORD-00292528,_ORD-00292529_Direct_Apple_MGOMD_RT_Marcomms_FebMarchLD",1965163,Entertainment,2025-01-01,285727,526
+Apple,ORD-00295569_Direct_Apple_SlowHorsesS5_ RT_Sept_LD,2125041,Entertainment,2025-01-01,285703,4364
+Apple,ORD-00292815/ORD-00292816_Direct_Apple_YourFriendsandNeighbours_ RT_April_LD,1980492,Entertainment,2025-01-01,285653,2045
+Apple,ORD-00291957_Direct_Apple_TheGorge RT_Feb_LD,1926005,Entertainment,2025-01-01,285646,2537
+BSskyb,ORD-00295733_Sky X Netflix_Zenith_Partnership_September,2125057,Entertainment,2025-01-01,284455,0
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,284153,167
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,284106,252
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,284027,364
+Lidl,ORD-00288216_Direct_Lidl AppleandPears_sept24_LD,1768361,Supermarket,2024-01-01,283797,4134
+Chery,ORD-00297057 Chery Lead Gen_Top Gear Direct_Q4 2025,2228863,Motoring,2025-01-01,283324,2360
+Waitrose,PG_Waitrose_MGOMD_No1_Oct_LD,2139412,Supermarket,2025-01-01,283211,4520
+Live Nation,ORD-00285196_Crowded House Digital Q3,1691154,Entertainment,2024-01-01,282357,158
+ITV,ITV_EMX_Q4 24 Planning_Digital and Print ,1852125,Entertainment,2024-01-01,281061,5924
+The Walt Disney Company,PG_Disney_Elio_June_RON_02/06/25,2040079,Entertainment,2025-01-01,277795,2758
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,277003,188
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,276892,295
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,276872,264
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,276848,183
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,276818,220
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,276747,288
+Apple,ORD-00289207 _Direct_Apple_MGOMD_RT_Disclaimers_Oct_LD,1863561,Entertainment,2024-01-01,275865,90
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,275184,236
+Aldi,PG_Aldi_Valentines Day Feb,1907210,Food,2025-01-01,274929,5076
+Damart,PG_Damart_26_IMAud_Oct -Nov 24,1807189,Supermarket,2024-01-01,271654,0
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,270958,199
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,270945,295
+Jaguar Landrover,ORD-00297215_Direct - JLR_H&S_RSV-Nov-Dec_LD,2185133,Motoring,2025-01-01,270835,213
+Jaguar Landrover,ORD-00297215_Direct - JLR_H&S_RSV-Nov-Dec_LD,2185133,Motoring,2025-01-01,270832,463
+Jaguar Landrover,ORD-00297215_Direct - JLR_H&S_RSV-Nov-Dec_LD,2185133,Motoring,2025-01-01,270831,182
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,270555,246
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,270541,239
+Birds Eye,ORD-00298551_Birds Eye Peas - Zenith - March - April,2277873,Food,2026-01-01,270390,1103
+Hays Travel - June ,ORD-00294354 Hays Travel_ ARM_ Digital_ Ambassador_ june,2034225,Travel,2025-01-01,269963,85
+AEG,ORD-00292038_Diana Ross AEG Digital 2025 Q1,1938716,Entertainment,2025-01-01,268909,409
+Aldi,Aldi_Sept & Oct_Olive_GoodFood_Specially Selected,2108083,Supermarket,2025-01-01,268805,88
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,266665,856
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,264608,5207
+Apple,ORD-00292815/ORD-00292816_Direct_Apple_YourFriendsandNeighbours_ RT_April_LD,1980492,Entertainment,2025-01-01,263639,2192
+Disney+,PG_Disney+_Zenith_The Bear S3 2024,1671677,Entertainment,2024-01-01,263431,5135
+Skoda,ORD-00271360 _Direct_ SkodaFleet_PHD_H2_2023_LD,1466969,Motoring,2024-01-01,263387,3498
+HBO Max,ORD-00299155_HBOMAX_Radio_Times_2026,2293143,Entertainment,2026-01-01,260423,6703
+Superdrug,ORD-00298203_Direct_Digi_Superdrug_GoodFood_Jan2026,2232195,Health,2026-01-01,260406,282
+Sarson's,ORD-00288776_Sarsons Vinegar_Brewed for Food Burst 2_Food_Sep24,1789636,Food,2024-01-01,260038,213
+Sarson's,ORD-00288776_Sarsons Vinegar_Brewed for Food Burst 2_Food_Sep24,1789636,Food,2024-01-01,260035,256
+Sarson's,ORD-00288776_Sarsons Vinegar_Brewed for Food Burst 2_Food_Sep24,1789636,Food,2024-01-01,260028,414
+Sarson's,ORD-00288776_Sarsons Vinegar_Brewed for Food Burst 2_Food_Sep24,1789636,Food,2024-01-01,260005,120
+Sarson's,ORD-00288776_Sarsons Vinegar_Brewed for Food Burst 2_Food_Sep24,1789636,Food,2024-01-01,260002,612
+Renault,ORD-00298920/ORD-00298921_Direct_Alpine_MGOMD_TG_Q1_EC,2256697,Motoring,2026-01-01,259278,136
+Lidl,ORD-00288216_Direct_Lidl AppleandPears_sept24_LD (Correct),1761875,Supermarket,2024-01-01,258949,3715
+Renault,ORD-00298920/ORD-00298921_Direct_Alpine_MGOMD_TG_Q1_EC,2256697,Motoring,2026-01-01,258831,368
+The Walt Disney Company,Order_PG_Disney_Zenith_Hoppers,2259041,Entertainment,2026-01-01,257232,2087
+Jaguar Landrover,ORD-00292004 Direct - AUV_JLR_H&S_Feb-April 2025,1908230,Motoring,2025-01-01,256831,336
+Hendricks ,ORD-00294564_Hendrick's Display - June/July 2025,2048762,Alcohol,2025-01-01,255167,508
+Alpen,ORD-00277683_Alpen_GetMeMedia_Nov-Sept,1601248,Food,2024-01-01,254928,417
+Pernod Ricard,ORD-00284976_Direct_MGOMD_Pernod_Absolut_Alwayson_Jul-Dec_LD (Passionfruit),1680354,Alcohol,2024-01-01,253000,822
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,250137,61
+Abarth,ORD-00293456_Abarth 600E_Q2_TG,1974081,Motoring,2025-01-01,250061,2285
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,250037,77
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,250035,65
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,250021,83
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,250019,97
+Winalot,Winalot 2024_OpenMind_WPP,1647224,Pets,2024-01-01,250016,67
+Winalot,Winalot 2024_OpenMind_WPP,1647224,Pets,2024-01-01,250014,80
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,250007,40
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,250006,92
+Disney+,PG_Disney_Inside Out 2 EHV_Aug 24,1731379,Entertainment,2024-01-01,250004,2045
+Astus,ORD-00289352_Yorkshire Provender Q4 2024,1875587,Food,2024-01-01,250002,140
+Astus,ORD-00289352_Yorkshire Provender Q4 2024,1875587,Food,2024-01-01,250002,457
+Morrisons,ORD-00283323_Morrisons_Wavemaker_May-Nov 2024 partnership,1640453,Supermarket,2024-01-01,250002,2104
+Finish,ORD-00285482 & ORD-00285447_Finish_Zenith_Q3,1696536,Food,2024-01-01,250001,83
+Centrum,ORD-00298340/ORD-00298146/ Centrum2026Partnership_Spark,2260270,Health,2026-01-01,250000,703
+Chery,ORD-00297057 Chery Lead Gen_Top Gear Direct_Q4 2025,2228863,Motoring,2025-01-01,249998,111
+Morrisons,ORD-00283323_Morrisons_Wavemaker_May-Nov 2024 partnership,1640453,Supermarket,2024-01-01,249995,3706
+Chery,ORD-00297057 Chery Lead Gen_Top Gear Direct_Q4 2025,2228863,Motoring,2025-01-01,249986,99
+Nacon,ORD-00287184 TestDriveUnlimited_IM_Gaming/TG/RT_Sept24,1830729,Gaming,2024-01-01,249984,5954
+Princess Cruises ,ORD-00277435_Princess 24 partnership_7 STars_Dec-May,1525755,Travel,2024-01-01,249915,163
+Apple,ORD-00290658/ORD-00290661_Direct_Apple_Iphone14Pro RT_LPTO_Nov-Dec-LD,1869545,Entertainment,2024-01-01,248280,121
+The Walt Disney Company,PG_Disney_Elio_June_RON_02/06/25,2040079,Entertainment,2025-01-01,248151,5179
+The Walt Disney Company,PG_NatGeo_Zenith_Top_Gun_19th_September,2125006,Entertainment,2025-01-01,247584,109
+Lidl,PMP_Lidl_OMD_Fruit_playstream_22/5-22/5,1681166,Supermarket,2024-01-01,246022,3799
+The Walt Disney Company,Order_PG_Disney_Zenith_Hoppers,2259041,Entertainment,2026-01-01,245908,4982
+AMEX,PG_AMEX_IPG Kinesso_H1 Gold & Platinum_18/03-26/05/26_RT,2289056,Finance,2026-01-01,244491,6287
+Visit Orlando,ORD-00295890 Visit Orlando Display,2161910,Travel,2025-01-01,243190,144
+Damart - Black Friday,PG_Damart_26_IMAud_Black-Friday,1835356,Supermarket,2024-01-01,241217,0
+AMEX,PG_AMEX_IPG Kinesso_H1 Gold & Platinum_18/03-26/05/26_RT,2289056,Finance,2026-01-01,240001,4913
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,239301,2434
+Sky,ORD-00291224_sky screen test Lockerbie,1887190,Entertainment,2024-01-01,238890,5640
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,238828,321
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,238536,503
+Disney+,PG_Disney_Inside Out 2 EHV_Aug 24,1731379,Entertainment,2024-01-01,236704,4042
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,235308,8527
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,235302,8408
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,235299,7312
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,235297,7979
+bet365,ORD-00278321 _bet365 H1 2024,1524821,Gambling,2024-01-01,235297,6413
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,235294,8577
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,235294,8421
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,234832,973
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,232779,93
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,232718,1998
+Mattel UK,ORD-00295966_Mattel_UM_Mattel Hot Wheels_15.09,2139285,Entertainment,2025-01-01,231461,2199
+Apple,ORD-00288149+ORD-00287960 Apple Slow Horses x BFI,1770104,Entertainment,2024-01-01,230776,6271
+Paramount+,Paramount+_Wavemaker_High Stakes Drama_APP,1808893,Entertainment,2024-01-01,228637,4695
+Paramount+,Paramount+_Wavemaker_High Stakes Drama_APP,1808893,Entertainment,2024-01-01,228587,3897
+Apple,ORD-00293816_Direct_MGOMD_Apple_FountainOfYouth_ RT_May_LD,2009825,Entertainment,2025-01-01,228567,2090
+Apple,ORD-00290229/ORD-00290227Direct_Apple_MGOMD_RT_BadSisters_Nov_LD,1869269,Entertainment,2024-01-01,227181,2041
+Kerrygold,ORD-00299430_Kerrygold_PHD_GF_StPatricksDay_Skin&MMA_Mar25,2280231,Food,2026-01-01,225162,3834
+Florette,ORD-00292672_Florette_Caratleeds_Partnership_May-July2025,1993798,Food,2025-01-01,225098,381
+Florette,ORD-00292672_Florette_Caratleeds_Partnership_May-July2025,1993798,Food,2025-01-01,225074,436
+Uzbekistan Food Festival,ORD-00293966_Direct_Uzbekistan_Dars Consulting_Q2,2049227,Food,2025-01-01,224783,285
+bet365,ORD-00294741_bet365 H2 2025,2079425,Gambling,2025-01-01,222300,63
+Apple,"ORD-00292528,_ORD-00292529_Direct_Apple_MGOMD_RT_Marcomms_FebMarchLD",1965163,Entertainment,2025-01-01,222239,1100
+Marks & Spencer,ORD-00290864 Direct-M&S-Mindshare- Xmas digital - 4th November - 28th November,1876342,Food,2024-01-01,222234,4495
+Aldi,ORD-00295386_Direct_Aldi_August_Digi_2025,2080311,Supermarket,2025-01-01,222225,6164
+Hendricks ,ORD-00294564_Hendrick's Display - June/July 2025,2048762,Alcohol,2025-01-01,222198,4472
+Centrum,ORD-00298340/ORD-00298146/ Centrum2026Partnership_Spark,2260270,Health,2026-01-01,221517,74
+Live Nation,ORD-00286341_Janet Jackson July,1701945,Entertainment,2024-01-01,221043,104
+Wargaming Group Ltd,ORD-00278599_WarThunder_IM_Hist/RT_2024,1596290,Gaming,2024-01-01,220802,63
+Finish,ORD-00285482 & ORD-00285447_Finish_Zenith_Q3,1696536,Food,2024-01-01,220630,1623
+Apple,ORD-00290229/ORD-00290227Direct_Apple_MGOMD_RT_BadSisters_Nov_LD,1869269,Entertainment,2024-01-01,220002,5225
+Dacia,ORD-00294469 _Direct_MGOMD_Dacia_Spring_TG_EV_Awards_LD,2044326,Motoring,2025-01-01,218967,2043
+Immediate Media,Amazon XCM - Eclipse Takeover. 20/11/25,2187664,Retail,2025-01-01,218856,0
+Dacia,ORD-00294469 _Direct_MGOMD_Dacia_Spring_TG_EV_Awards_LD,2044326,Motoring,2025-01-01,218017,5729
+Kerrygold,ORD-00292017_Kerrygold_PHDManchester_partnership2025,1959016,Food,2025-01-01,217440,495
+Pernod Ricard,ORD-00288373_Direct_MGOMD_Pernod_Absolut/Kahlua_Q4_LD,1785564,Alcohol,2024-01-01,216756,1093
+Wargaming Group Ltd,ORD-00278599_WarThunder_IM_Hist/RT_2024,1596290,Gaming,2024-01-01,215417,2628
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,213567,5558
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,213565,4639
+Immediate Media,Amazon XCM - Eclipse Takeover. 20/11/25,2187664,Retail,2025-01-01,212809,1002
+Warner - Tom Kerridge,ORD-00287390_Warner_TomKerridgeShow_Sep,1775134,Entertainment,2024-01-01,211122,1889
+Mattel UK,ORD-00295966_Mattel_UM_Mattel Hot Wheels_15.09,2139285,Entertainment,2025-01-01,211082,1993
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,210387,22
+Positec Worx,ORD-00288027/ORD-00288030_Positec Q4 Burst - Worx,1876392,Gardening,2024-01-01,210000,615
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,209966,30
+Hays Travel,ORD-00295430 Hays Travel_ All Response_ Digital_ NCL_Aug,2092709,Travel,2025-01-01,209457,234
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,209343,52
+Ruth Strauss,ORD-00285760 Ruth Strauss 2024,1700065,Health,2024-01-01,208608,94
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,208380,3143
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,208371,4236
+Superdrug,ORD-00298203_Direct_Digi_Superdrug_GoodFood_Jan2026,2232195,Health,2026-01-01,208366,47
+Superdrug,ORD-00298203_Direct_Digi_Superdrug_GoodFood_Jan2026,2232195,Health,2026-01-01,208364,67
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,208355,168
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,208334,123
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,208237,852
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,208208,9400
+Diageo,Diageo_JohnnieWalkerBlack_Sep-Dec (Native),1817891,Alcohol,2024-01-01,208141,2386
+Arla,PG_Arla_Baileys_Xmas_24,1878795,Food,2024-01-01,207549,2026
+Arla Lurpak,PG_Arla_Baileys_Xmas_24,1880693,Food,2024-01-01,207549,2026
+Arla Lurpak,PG_Arla_Baileys_Xmas_24,1880693,Food,2024-01-01,207539,2646
+Arla,PG_Arla_Baileys_Xmas_24,1878795,Food,2024-01-01,207539,2646
+Disney+,PG_Disney_Moana 2_Nov 2024,1827805,Entertainment,2024-01-01,207513,4709
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,207233,3987
+Apple,ORD-00286876 _Direct_Apple_MGOMD_BadMonkey_Aug_LD,1721087,Entertainment,2024-01-01,206896,66
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,206501,2935
+Dacia,PG_MGOMD_DaciaSpring_TopGear_July-Sept_LD,1819886,Motoring,2024-01-01,205703,72
+Dacia,PG_MGOMD_DaciaSpring_TopGear_July-Sept_LD,1819886,Motoring,2024-01-01,205700,280
+Dacia,PG_MGOMD_DaciaSpring_TopGear_July-Sept_LD,1819886,Motoring,2024-01-01,205700,105
+Dacia,PG_MGOMD_DaciaSpring_TopGear_July-Sept_LD,1819886,Motoring,2024-01-01,205691,127
+Dacia,PG_MGOMD_DaciaSpring_TopGear_July-Sept_LD,1819886,Motoring,2024-01-01,205685,96
+Diageo,Diageo_JohnnieWalkerBlack_Sep-Dec (Native),1817891,Alcohol,2024-01-01,201612,1698
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,200735,241
+Diageo,ORD-00290179_Diageo_Whisky_Widget_PHD_Jan-June25,1953536,Alcohol,2025-01-01,200659,30
+Diageo,ORD-00290179_Diageo_Whisky Widget_PHD_Jan-June25,1938830,Alcohol,2025-01-01,200659,30
+Peter Nyssen,"ORD-00290406_Peter Nyssen Competition, Solus, Social Carousel, Skins 01.08.2025 - 31.10.2025",2113782,Gardening,2025-01-01,200114,7144
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,200094,3486
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200056,48
+Beko,ORD-00293616_Beko_RunningTotal_GFKitchenvalue2025,1973988,Tech,2025-01-01,200047,5338
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200036,13
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,200031,70
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,200029,33
+Holland & Barrett,ORD-00291348_H&B P3 Nutrition_Skins&MMA_Jan 25,1879540,Health,2025-01-01,200021,203
+Paramount+,Paramount+_Wavemaker_High Stakes Drama_APP,1808893,Entertainment,2024-01-01,200021,2036
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200018,269
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200016,208
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200016,103
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200014,375
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200010,581
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,200010,32
+HBO Max,ORD-00299155_HBOMAX_Radio_Times_2026,2293143,Entertainment,2026-01-01,200009,1340
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200007,6
+Cuprinol,ORD-00280426_Cuprinol_Q2 2024_Partnership_Mediahub,1580624,Health,2024-01-01,200007,237
+Ocado,ORD-00285279_Ocado Made For Mums 2024,1798599,Parenting,2024-01-01,200006,2316
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200006,10
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200006,79
+bet365,ORD-00278321 _bet365 H1 2024,1524821,Gambling,2024-01-01,200004,67
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200004,306
+Astus,ORD-00289352_Yorkshire Provender Q4 2024,1875587,Food,2024-01-01,200004,487
+Paramount+,Paramount+_Wavemaker_High Stakes Drama_APP,1808893,Entertainment,2024-01-01,200004,4649
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,200003,76
+OOONO,ORD-00292370_OOONO Digital Advertorial,1962165,Entertainment,2025-01-01,200002,1566
+bet365,ORD-00285518_bet365 H2 2024,1698422,Gambling,2024-01-01,200002,178
+bet365,ORD-00278321 _bet365 H1 2024,1524821,Gambling,2024-01-01,200001,36
+Holland & Barrett,ORD-00291348_H&B P3 Nutrition_Skins&MMA_Jan 25,1879540,Health,2025-01-01,200001,415
+Astus,ORD-00289352_Yorkshire Provender Q4 2024,1875587,Food,2024-01-01,200000,214
+Apple,ORD-00291957_Direct_Apple_TheGorge RT_Feb_LD,1926005,Entertainment,2025-01-01,199609,4370
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,199439,244
+Peugeot,ORD-00298865_Direct_Digi_Peugeot_Q1_2026,2280253,Motoring,2026-01-01,198407,2106
+Pernod Ricard,ORD-00284977 _Direct_MGOMD_Pernod_Malibu_Alwayson_Jul-Dec_LD,1680361,Alcohol,2024-01-01,196097,873
+Pernod Ricard,ORD-00291461/ORD-00291460_Dentsu_Pernod Ricard_2025,1878661,Alcohol,2024-01-01,196097,873
+Warner Hotels ,ORD-00294552_Warner Hotels_History Weekends_Sept-Nov,2105455,Travel,2025-01-01,194919,133
+Disney+,PG_Disney+_Zenith_The Stolen Girl_16 April - 4th May,1976741,Entertainment,2025-01-01,194493,2393
+Morrisons,ORD-00287596_Morrisons Christmas 2024_Wavemaker_Nov-Dec 24,1845134,Supermarket,2024-01-01,193744,1796
+Apple,ORD-00295569_Direct_Apple_SlowHorsesS5_ RT_Sept_LD,2125041,Entertainment,2025-01-01,193627,4020
+Jaguar Landrover,ORD-00295165_Direct _JLR_He&S_Multibrand_Q3-2026_LD,2074264,Motoring,2025-01-01,193588,77
+Nutracheck,Nutracheck,1856812,On-Demand,2024-01-01,192711,58
+Nintendo,ORD-00288651 Nintendo: Echoes of Wisdom,1814079,Gaming,2024-01-01,192310,1750
+Laithwaites,Marketing-house-external-partnership,2157559,Alcohol,2025-01-01,191817,35
+HBO Max,ORD-00299155_HBOMAX_Radio_Times_2026,2293143,Entertainment,2026-01-01,191755,4981
+Morrisons,Morrisons_W/M_JulyUpweight,2060643,Supermarket,2025-01-01,191473,5632
+Cuprinol,ORD-00280426_Cuprinol_Q2 2024_Partnership_Mediahub,1580624,Health,2024-01-01,190003,98
+The Walt Disney Company,PG_Disney+_Amanda Knox_Video RT,2249392,Entertainment,2025-01-01,189389,90
+Live Nation,ORD-00284195_Live Nation- Spanish Riding School of Vienna,1652589,Entertainment,2024-01-01,188203,97
+Alfa Romeo,ORD-00294948_Direct_Alfa Romeo_Q3_2025,2086008,Motoring,2025-01-01,187670,124
+Alfa Romeo,ORD-00294948_Direct_Alfa Romeo_Q3_2025,2086008,Motoring,2025-01-01,187616,92
+Morrisons,ORD-00287596_Morrisons Christmas 2024_Wavemaker_Nov-Dec 24,1845134,Supermarket,2024-01-01,187511,108
+Morrisons,ORD-00287596_Morrisons Christmas 2024_Wavemaker_Nov-Dec 24,1845134,Supermarket,2024-01-01,187502,102
+River Street Events,ORD-00291522_RiverStreet_3shows_20thMarch30th August,2027374,Gardening,2025-01-01,187498,621
+Peugeot,ORD-00294321_Direct_Peugeot e3008_Q2_2025,2030170,Motoring,2025-01-01,186899,1898
+Renault,ORD-00296021_Direct_Renault_MGOMD_R4_TG_Sept_LD,2130221,Motoring,2025-01-01,185873,795
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,185716,141
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,184803,697
+Fortnum and Mason, PG_F&M Xmas25_26PMX_IMAudHigh Impact_GF_V2,2175953,Retail,2025-01-01,184358,2970
+Apple,ORD-00292815/ORD-00292816_Direct_Apple_YourFriendsandNeighbours_ RT_April_LD,1980492,Entertainment,2025-01-01,182919,52
+HBO Max,ORD-00299155_HBOMAX_Radio_Times_2026,2293143,Entertainment,2026-01-01,181915,1094
+Immediate Media,Amazon XCM - Eclipse Takeover. 20/11/25,2187664,Retail,2025-01-01,179741,1757
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,179421,2507
+Warner Leisure,ORD-00278268 & ORD-00278274_Warner Leisure Hotels-Q4 2023 / Q1-2 2024,1510991,Travel,2024-01-01,178777,1020
+Jaguar Landrover,ORD-00292004 Direct - AUV_JLR_H&S_Feb-April 2025,1908230,Motoring,2025-01-01,178563,198
+Warner Hotels ,ORD-00297387 - Warner History weekends 2026,2254240,Entertainment,2026-01-01,176525,118
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,176190,648
+shell,ORD-00286771_Shell x Top Gear VPower,1733425,Motoring,2024-01-01,175715,174
+Kerrygold,ORD-00292017_Kerrygold_PHDManchester_partnership2025,1959016,Food,2025-01-01,175013,213
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,175010,137
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,175003,147
+Kerrygold,ORD-00292017_Kerrygold_PHDManchester_partnership2025,1959016,Food,2025-01-01,174992,301
+Nintendo,ORD-00288651 Nintendo: Echoes of Wisdom,1814079,Gaming,2024-01-01,173950,1094
+BSskyb,ORD-00295733_Sky X Netflix_Zenith_Partnership_September,2125057,Entertainment,2025-01-01,173665,1306
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,173191,122
+Windsor Castle,ORD-00293267_Windsor Castle - June to August 2025,2094137,History,2025-01-01,173077,2357
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,172702,13
+Apple,ORD-00290229/ORD-00290227Direct_Apple_MGOMD_RT_BadSisters_Nov_LD,1869269,Entertainment,2024-01-01,172417,49
+Pernod Ricard,ORD-00291461/ORD-00291460_Dentsu_Pernod Ricard_2025,1878661,Alcohol,2025-01-01,171968,608
+National Geographic,PG_Nat Geo: Megastructures_Dec 2024,1857117,Entertainment,2024-01-01,171714,0
+Apple,ORD-00286876 _Direct_Apple_MGOMD_BadMonkey_Aug_LD,1721087,Entertainment,2024-01-01,171435,1602
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,171312,224
+Itsu ,ORD-00287826_Direct - Itsu_Yonder_Summer Brief_Sept 2024,1748340,Food,2024-01-01,171226,36
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,170551,15
+Kerrygold,ORD-00292017_Kerrygold_PHDManchester_partnership2025,1959016,Food,2025-01-01,169314,1486
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,167566,121
+Abarth,ORD-00293456_Abarth 600E_Q2_TG,1974081,Motoring,2025-01-01,167402,1657
+Mattel UK,ORD-00295966_Mattel_UM_Mattel Hot Wheels_15.09,2139285,Entertainment,2025-01-01,166743,608
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,166720,234
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,166705,102
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,166694,271
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,166681,296
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,166674,242
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,166673,160
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,166671,179
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,166671,155
+The Walt Disney Company,PG_NatGeo_Zenith_Top_Gun_19th_September,2125006,Entertainment,2025-01-01,166669,129
+The Walt Disney Company,PG_Disney_Elio_June_RON_02/06/25,2040079,Entertainment,2025-01-01,166654,1556
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,166643,140
+The Walt Disney Company,PG_Disney+_Amanda Knox_Video RT,2249392,Entertainment,2025-01-01,165959,88
+Carte D'Or,PG_Digi_Carte D'Or_Q2,1616515,Food,2024-01-01,165344,2685
+The Walt Disney Company,Order_PG_Disney_Zenith_Hoppers,2259041,Entertainment,2026-01-01,164440,1436
+The Walt Disney Company,Order_PG_Disney_Zenith_Hoppers,2259041,Entertainment,2026-01-01,164344,4032
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,162877,3
+Itsu ,ORD-00287826_Direct - Itsu_Yonder_Summer Brief_Sept 2024,1748340,Food,2024-01-01,161296,1704
+Crowded House,ORD-00288258 Crowded House Aug-Sept,1744789,Entertainment,2024-01-01,160017,203
+Apple,ORD-00293816_Direct_MGOMD_Apple_FountainOfYouth_ RT_May_LD,2009825,Entertainment,2025-01-01,159919,4351
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2026-01-01,159576,3918
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,159571,3814
+Saga,ORD-00284736 Saga Holiday_Dentsu_Skin+Standard_Jul24,1664796,Travel,2024-01-01,158733,287
+Pernod Ricard,ORD-00291461/ORD-00291460_Dentsu_Pernod Ricard_2025,1878661,Alcohol,2025-01-01,158600,840
+Carte D'Or,PG_Digi_Carte D'Or_Q2,1616515,Food,2024-01-01,158346,2310
+Warner Leisure,ORD-00278268 & ORD-00278274_Warner Leisure Hotels-Q4 2023 / Q1-2 2024,1510991,Travel,2024-01-01,158010,691
+Diageo,ORD-00288038_(Diageo) Casamigos_Repurposed_PHD_July24June25,1777213,Alcohol,2024-01-01,157967,555
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,157618,2327
+Abarth,ORD-00293456_Abarth 600E_Q2_TG,1974081,Motoring,2025-01-01,157014,2981
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2024-01-01,156865,64
+Cupra,Cupra_PHD_BornCampaign_Q4,1901398,Motoring,2024-01-01,156865,64
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2024-01-01,156861,206
+Cupra,Cupra_PHD_BornCampaign_Q4,1901398,Motoring,2024-01-01,156861,206
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2024-01-01,156854,108
+Cupra,Cupra_PHD_BornCampaign_Q4,1901398,Motoring,2024-01-01,156854,108
+Carte D'Or,PG_Digi_Carte D'Or_Q2,1616515,Food,2024-01-01,156677,1854
+Positec Worx,ORD-00288027/ORD-00288030_Positec Q4 Burst - Worx,1876392,Gardening,2024-01-01,156267,3915
+Positec Worx,ORD-00288027_Positec Q4 Burst - Worx,1804403,Gardening,2024-01-01,156267,1967
+Positec Worx,ORD-00288027/ORD-00288030_Positec Q4 Burst - Worx,1876392,Gardening,2024-01-01,156267,1967
+Positec Worx,ORD-00288027_Positec Q4 Burst - Worx,1804403,Gardening,2024-01-01,156267,3915
+National Geographic,PG_Nat Geo: Megastructures_Dec 2024,1857117,Entertainment,2024-01-01,155636,111
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,155163,1449
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,155146,1427
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,155138,1420
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,155134,1455
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,155118,1070
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,155116,1051
+Diageo,ORD-00288038_(Diageo) Casamigos_Repurposed_PHD_July24June25,1777213,Alcohol,2024-01-01,154861,723
+Apple,ORD-00288525_Direct_Apple_MGOMD_RT_Wolfs_Sept_LD,1768307,Entertainment,2024-01-01,154306,1359
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,153359,201
+Merchant Gourmet,ORD-00291231_Merchant Gourmet_Yonder_Good Food_January 2025,1895723,Food,2025-01-01,152729,272
+Abbott,ORD-00287639_Abbott_Freestyle Libre Healthy Diet_2024,1805926,Food,2024-01-01,152716,50
+P&O Cruises,ORD-00299893_P&O Cruises BAFTA award promotion_Wavemaker_Mar-Apr26,2290174,Travel,2026-01-01,151539,794
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,150187,131
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,150061,52
+Centrum,ORD-00291473_Centrum_Spark_Vitamins 2025,1896853,Health,2025-01-01,150054,1625
+Centrum,ORD-00291473_Centrum_Spark_Vitamins 2025,1896853,Health,2025-01-01,150029,936
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,150019,339
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,150014,355
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,150013,121
+River Street Events,ORD-00291522_RiverStreet_3shows_20thMarch30th August,2027374,Gardening,2025-01-01,150011,98
+River Street Events,ORD-00291522_RiverStreet_3shows_20thMarch30th August,2027374,Gardening,2025-01-01,150004,131
+River Street Events,ORD-00291522_RiverStreet_3shows_20thMarch30th August,2027374,Gardening,2025-01-01,150004,112
+American Pistachio,ORD-00293270/ORD-00293326_American Pistachio_Summer2025_Print_Digi_GF_GW,2005736,Food,2025-01-01,150003,180
+Nacon,ORD-00287184 TestDriveUnlimited_IM_Gaming/TG/RT_Sept24,1830729,Gaming,2024-01-01,150002,1452
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,150002,82
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,150002,290
+American Pistachio,ORD-00293270/ORD-00293326_American Pistachio_Summer2025_Print_Digi_GF_GW,2005736,Food,2025-01-01,150000,317
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,150000,204
+Winalot,Winalot 2024_OpenMind_WPP,1647224,Pets,2024-01-01,150000,150
+ASDA,ASDA_Spark_AV,2226535,Supermarket,2025-01-01,149995,170
+Nacon,ORD-00287184 TestDriveUnlimited_IM_Gaming/TG/RT_Sept24,1830729,Gaming,2024-01-01,149989,1033
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,149987,113
+Warner Leisure,ORD-00278268 & ORD-00278274_Warner Leisure Hotels-Q4 2023 / Q1-2 2024,1510991,Travel,2024-01-01,149395,1094
+Centrum,ORD-00298340/ORD-00298146/ Centrum2026Partnership_Spark,2260270,Health,2026-01-01,148836,695
+Inspired Villages Group Limited,ORD-00284044_Inspired Villages Soap Awards,1701686,Entertainment,2024-01-01,147976,148
+Hays Travel - June ,ORD-00293796 hays Travel_ ARM_ Digital_ May,2020315,Travel,2025-01-01,147829,85
+Sainsburys,ORD-00294588_Sainsbury's x Good Food TTD P2 June-August,2045562,Supermarket,2025-01-01,147646,2789
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2026-01-01,147102,441
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,146310,247
+National Geographic,PG_Nat Geo_Zenith_David Blaine_24/03/25,1943612,Entertainment,2025-01-01,145730,1697
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,145714,123
+Nacon,ORD-00294535 Nacon_Architect Life_IM_July_RT,2064490,Gaming,2025-01-01,144975,2883
+Wargaming Group Ltd,ORD-00278599_WarThunder_IM_Hist/RT_2024,1596290,Gaming,2024-01-01,144447,1385
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1962013,Motoring,2025-01-01,144110,46
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,143939,118
+Aldi,PG_Aldi_Valentines Day Feb,1907210,Food,2025-01-01,142981,1393
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,142887,138
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,142879,63
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,142871,123
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,142860,428
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,1833125,Food,2024-01-01,142857,153
+Quickline Broadband,Quickline Broadband_ORD-00298403&ORD-00298567,2237189,Tech,2026-01-01,142857,999
+Skoda,ORD-00271360 _Direct_ SkodaFleet_PHD_H2_2023_LD,1466969,Motoring,2024-01-01,141169,55
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,141133,1359
+Alpen,ORD-00277683_Alpen_GetMeMedia_Nov-Sept,1601248,Food,2024-01-01,140329,4023
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1962013,Motoring,2025-01-01,140003,842
+The Crown Estate,ORD-00284347_The Crown Estate - GW 2024 Campaign,1680347,Parenting,2024-01-01,140000,5158
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,139114,133
+Pernod Ricard,ORD-00291461/ORD-00291460_Dentsu_Pernod Ricard_2025,1878661,Alcohol,2025-01-01,138676,671
+Warner - Tom Kerridge,ORD-00287390_Warner_TomKerridgeShow_Sep,1775134,Entertainment,2024-01-01,138094,2224
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,138006,543
+Hays Travel - Jan 2025,ORD-00291728 Hays Travel_ All response_ Digital_ NCL_ 13/01,1900544,Travel,2025-01-01,137157,86
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1982913,Motoring,2025-01-01,136410,827
+Apple,ORD-00292815/ORD-00292816_Direct_Apple_YourFriendsandNeighbours_ RT_April_LD,1980492,Entertainment,2025-01-01,136260,4008
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1962013,Motoring,2025-01-01,135836,100
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,134769,254
+Apple,ORD-00295569_Direct_Apple_SlowHorsesS5_ RT_Sept_LD,2125041,Entertainment,2025-01-01,134672,45
+Disney+,PG_Disney_Inside Out 2 EHV_Aug 24,1731379,Entertainment,2024-01-01,134006,1246
+Alfa Romeo,ORD-00294948_Direct_Alfa Romeo_Q3_2025,2086008,Motoring,2025-01-01,133330,58
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1982913,Motoring,2025-01-01,133031,44
+Alfa Romeo,ORD-00294948_Direct_Alfa Romeo_Q3_2025,2086008,Motoring,2025-01-01,132911,34
+Dacia,ORD-00294469 _Direct_MGOMD_Dacia_Spring_TG_EV_Awards_LD,2044326,Motoring,2025-01-01,132202,119
+Dacia,ORD-00294469 _Direct_MGOMD_Dacia_Spring_TG_EV_Awards_LD,2044326,Motoring,2025-01-01,132118,42
+Grana Padano,ORD-00290516_Grana_Padano_Xmas_GF_24,1878439,Food,2024-01-01,132004,290
+Live Nation,ORD-00287785_Jonas Brothers Q3 Digital,1763475,Entertainment,2024-01-01,132000,313
+Apple,ORD-00295569_Direct_Apple_SlowHorsesS5_ RT_Sept_LD,2125041,Entertainment,2025-01-01,131999,28
+Eco Manure,"ORD-00293368/ORD-00293759_Eco Manure_HP, Solus, Social, Comp & Display",2048752,Gardening,2025-01-01,131919,592
+National Geographic,PG_Nat Geo: Defending Europe_RT History Sep,1760336,Entertainment,2024-01-01,131884,156
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,131701,1460
+Carte D'Or,PG_Digi_Carte D'Or_Q2,1616515,Food,2024-01-01,131199,1514
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,130961,78
+Carte D'Or,PG_Digi_Carte D'Or_Q2,1616515,Food,2024-01-01,130837,1602
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,130725,201
+National Geographic,PG_Nat Geo: Defending Europe_RT History Sep,1760336,Entertainment,2024-01-01,129140,2293
+Immediate Media,Amazon XCM - Eclipse Takeover. 20/11/25,2187664,Retail,2025-01-01,128995,1378
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,128386,52
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,128375,7
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,128349,1147
+Dacia,ORD-00289659_Direct_MGOMD_DaciaSpring_TopGear_Oct,1827785,Motoring,2024-01-01,128126,162
+Dacia,ORD-00289659_Direct_MGOMD_DaciaSpring_TopGear_Oct,1827785,Motoring,2024-01-01,128124,159
+Dacia,ORD-00289659_Direct_MGOMD_DaciaSpring_TopGear_Oct,1827785,Motoring,2024-01-01,128124,164
+Dacia,ORD-00289659_Direct_MGOMD_DaciaSpring_TopGear_Oct,1827785,Motoring,2024-01-01,128124,81
+Dacia,ORD-00289659_Direct_MGOMD_DaciaSpring_TopGear_Oct,1827785,Motoring,2024-01-01,128040,327
+Toyota,PG_Toyota - Summer EV Range campaign 2024,1642790,Motoring,2024-01-01,127819,1057
+Toyota,PG_Toyota - Summer EV Range campaign 2024,1642790,Motoring,2024-01-01,127818,1085
+Toyota,PG_Toyota - Summer EV Range campaign 2024,1642790,Motoring,2024-01-01,127818,531
+Toyota,PG_Toyota - Summer EV Range campaign 2024,1642790,Motoring,2024-01-01,127817,1016
+Toyota,PG_Toyota - Summer EV Range campaign 2024,1642790,Motoring,2024-01-01,127816,922
+Asda,ORD-00290869 Direct - Asda_Spark_Christmas 2024,1870866,Food,2024-01-01,127776,217
+Winalot,Winalot 2024_OpenMind_WPP,1647224,Pets,2024-01-01,127757,102
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,127539,24
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,127041,56
+The Crown Estate,ORD-00295181_TCE FOF 25_RunningTotal_IMAud&MMA_AugSept25,2080345,Food,2025-01-01,126061,1152
+Grana Padano,ORD-00290516_Grana_Padano_Xmas_GF_24,1878439,Food,2024-01-01,125010,135
+Grana Padano,ORD-00290516_Grana_Padano_Xmas_GF_24,1878439,Food,2024-01-01,125008,151
+Grana Padano,ORD-00290516_Grana_Padano_Xmas_GF_24,1878439,Food,2024-01-01,125007,141
+Grana Padano,ORD-00290516_Grana_Padano_Xmas_GF_24,1878439,Food,2024-01-01,125004,168
+Uzbekistan Food Festival,ORD-00293966_Direct_Uzbekistan_Dars Consulting_Q2,2049227,Food,2025-01-01,125003,32
+River Street Events,ORD-00291522_RiverStreet_3shows_20thMarch30th August,2027374,Gardening,2025-01-01,125000,437
+River Street Events,ORD-00291522_RiverStreet_3shows_20thMarch30th August,2027374,Gardening,2025-01-01,125000,95
+Sainsburys,ORD-00293866_Sainsbury's Q2 TTD Campaign 2025,2003631,Supermarket,2025-01-01,123964,1441
+Morrisons,ORD-00292183_Morrisons 2025 partnership_Wavemaker_Feb-Oct25,1940739,Supermarket,2025-01-01,122855,863
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,122333,864
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,120074,175
+Kerrygold,ORD-00299430_Kerrygold_PHD_GF_StPatricksDay_Skin&MMA_Mar25,2280231,Food,2026-01-01,119052,854
+shell,ORD-00286771_Shell x Top Gear VPower,1733425,Motoring,2024-01-01,117861,55
+shell,ORD-00286771_Shell x Top Gear VPower,1733425,Motoring,2024-01-01,117860,47
+Ticketmaster,ORD-00290776_Ticketmaster 2- Sold Out - Display Campaign ,1839056,Entertainment,2024-01-01,117658,78
+Ticketmaster,ORD-00290776_Ticketmaster 2- Sold Out - Display Campaign ,1839056,Entertainment,2024-01-01,117648,324
+Ceres Walnuts,ORD-00296270_Ceres_Walnuts_OCT2025_GF,2153785,Food,2025-01-01,117451,41
+Ceres Walnuts,ORD-00296270_Ceres_Walnuts_OCT2025_GF,2153785,Food,2025-01-01,114797,35
+Ruth Strauss,ORD-00285760 Ruth Strauss 2024,1700065,Health,2024-01-01,113506,149
+Ruth Strauss,ORD-00285760 Ruth Strauss 2024,1700065,Health,2024-01-01,113501,256
+Arla,ORD-00293208_Arla_Lurpak_Easter_25_Value,1983591,Food,2025-01-01,113384,797
+Lidl,ORD-00288216_Direct_Lidl AppleandPears_sept24_LD (Correct),1761875,Supermarket,2024-01-01,113360,0
+Lidl,ORD-00288216_Direct_Lidl AppleandPears_sept24_LD,1768361,Supermarket,2024-01-01,113360,0
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,113090,85
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,112811,143
+Immediate Media,Amazon XCM - Eclipse Takeover. 20/11/25,2187664,Retail,2025-01-01,112399,11
+Centrum,ORD-00298340/ORD-00298146/ Centrum2026Partnership_Spark,2260270,Health,2026-01-01,112123,353
+Lidl,ORD-00292527_Direct_Lidl_Fresh_FebMarch25_LD,1981602,Food,2025-01-01,111368,0
+Abbott,ORD-00295651 Abbott Freestyle Libre ,2193187,Food,2025-01-01,111157,30
+Abbott,ORD-00295651 Abbott Freestyle Libre ,2193187,Food,2025-01-01,111148,48
+Disney+,Moana 2 2025,1902031,Entertainment,2025-01-01,111146,1327
+Abbott,ORD-00295651 Abbott Freestyle Libre ,2193187,Food,2025-01-01,111134,40
+The Walt Disney Company,PG_Disney_Elio_June_RON_02/06/25,2040079,Entertainment,2025-01-01,111123,873
+The Walt Disney Company,PG_Disney_Elio_June_RON_02/06/25,2040079,Entertainment,2025-01-01,111116,1060
+Abbott,ORD-00295651 Abbott Freestyle Libre ,2193187,Food,2025-01-01,111111,71
+Abbott,ORD-00295651 Abbott Freestyle Libre ,2193187,Food,2025-01-01,111109,39
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,110472,4070
+Live Nation,ORD-00287785_Jonas Brothers Q3 Digital,1763475,Entertainment,2024-01-01,110001,144
+The Walt Disney Company,Order_PG_Disney_Zenith_Hoppers,2259041,Entertainment,2026-01-01,109802,968
+Warner Brothers,ORD-00292957 Warner_MinecraftMovie_Mar-Apr,1946107,Entertainment,2025-01-01,109793,414
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1982913,Motoring,2025-01-01,109554,98
+De'longi,ORD-00279632_De'longi Tier 2 Olive,1577571,Food,2024-01-01,108815,2179
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,108626,1
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,108623,9
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,108591,653
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,108587,2457
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,108586,616
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,108582,3
+Quickline Broadband,Quickline Broadband_ORD-00298403&ORD-00298567,2237189,Tech,2026-01-01,108521,2811
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,107403,699
+shell,ORD-00294734_Shell F1 x Top Gear 2025,2071034,On-Demand,2025-01-01,107156,111
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,106302,1502
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,106001,25
+Warner Brothers,ORD-00292957 Warner_MinecraftMovie_Mar-Apr,1946107,Entertainment,2025-01-01,105857,413
+Warner Hotels ,ORD-00294552_Warner Hotels_History Weekends_Sept-Nov,2105455,Travel,2025-01-01,105581,2460
+Aldi,PG_Aldi Jan_Olive_GoodFood_FWO,1877174,Supermarket,2025-01-01,105560,877
+De'longi,ORD-00279632_De'longi Tier 2 Olive,1577571,Food,2024-01-01,105477,877
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,105085,1959
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,105081,2082
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,105080,1723
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,105079,1891
+De'Longhi,ORD-00287829_De'Longhi Manual H2 24,1785683,Food,2024-01-01,105076,1569
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,105072,1568
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,104768,265
+Disney+,PG_Digital_Disney_Zenith_InsideOut2MayJun-2024,1639286,Entertainment,2024-01-01,104352,587
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,103974,75
+Windsor Castle,ORD-00293267_Windsor Castle - June to August 2025,2094137,History,2025-01-01,103613,1866
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,103238,110
+Disney+,PG_Disney_Inside Out 2 D+ Campaign Oct 24,1770302,On-Demand,2024-01-01,102949,44
+The Baby Show,ORD-00292367_The Baby Show Excel London 2025,1951340,Parenting,2025-01-01,102906,528
+Disney+,PG_Disney_Inside Out 2 D+ Campaign Oct 24,1770302,On-Demand,2024-01-01,102889,60
+Disney+,PG_Disney_Inside Out 2 D+ Campaign Oct 24,1770302,On-Demand,2024-01-01,102862,91
+Disney+,PG_Disney_Inside Out 2 D+ Campaign Oct 24,1770302,On-Demand,2024-01-01,102860,135
+Disney+,PG_Disney_Inside Out 2 D+ Campaign Oct 24,1770302,On-Demand,2024-01-01,102826,91
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,102682,127
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,102616,88
+Bisodol,ORD-00293989 Bisodol_ Cornerstone_ GF_ print digi,2059527,Food,2025-01-01,102585,33
+Hays Travel - Jan 2025,ORD-00291728 Hays Travel_ All response_ Digital_ NCL_ 13/01,1900544,Travel,2025-01-01,102568,51
+Hays Travel - Jan 2025,ORD-00291728 Hays Travel_ All response_ Digital_ NCL_ 13/01,1900544,Travel,2025-01-01,102567,82
+Hays Travel,ORD-00297196 Hays Travel_ ARM_ Digital_ Nov_ princess,2177425,Travel,2025-01-01,102267,92
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,102265,17
+De'longi,ORD-00279632_De'longi Tier 2 Olive,1577571,Food,2024-01-01,101462,858
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,101177,31
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,100991,1119
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,100873,25
+Alpine,ORD-00293691_Direct_Alpine_MGOMD_A290_TG_April_LD,2013489,Motoring,2025-01-01,100104,84
+Alpine,ORD-00293691_Direct_Alpine_MGOMD_A290_TG_April_LD,2013489,Motoring,2025-01-01,100100,165
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,100098,1678
+Holland & Barrett,ORD-00291348_H&B P3 Nutrition_Skins&MMA_Jan 25,1879540,Health,2025-01-01,100033,26
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,100027,487
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,100017,23
+BBC Good Food,ORD-00292020_Tesco Food 3.0 - Feb Campaign. Digital,1912811,Supermarket,2025-01-01,100017,194
+BBC Good Food,ORD-00292020_Tesco Food 3.0 - Feb Campaign. Digital,1912811,Supermarket,2025-01-01,100016,198
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,100012,54
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,100010,18
+Playseat,ORD-00285484 Playseat_IM_TopGear_August,1731409,Gaming,2024-01-01,100006,357
+Hays Travel,ORD-00297196 Hays Travel_ ARM_ Digital_ Nov_ princess,2177425,Travel,2025-01-01,100003,66
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,100002,75
+Barretine Spring + Summer GW,ORD-00278706_Barretine Spring + Summer GW,1661668,Gardening,2024-01-01,100002,69
+Barretine Spring + Summer GW,ORD-00278706_Barretine Spring + Summer GW,1661668,Gardening,2024-01-01,100001,29
+Jaguar Landrover,ORD-00292004 Direct - AUV_JLR_H&S_Feb-April 2025,1908230,Motoring,2025-01-01,100001,39
+Barretine Spring + Summer GW,ORD-00278706_Barretine Spring + Summer GW,1661668,Gardening,2024-01-01,100000,79
+Nissan,ORD-00282051_Direct_MGOMD_Nissan_April_Qashqai_Q2_LD,1685416,Motoring,2024-01-01,100000,165
+Barretine Spring + Summer GW,ORD-00278706_Barretine Spring + Summer GW,1661668,Gardening,2024-01-01,100000,31
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,99996,39
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,99982,56
+Nissan,ORD-00282948_Direct_MGOMD_Nissan_May_Qashqai_Q2_LD,1669978,Motoring,2024-01-01,99971,203
+Nissan,ORD-00282948_Direct_MGOMD_Nissan_May_Qashqai_Q2_LD,1682744,Motoring,2024-01-01,99971,203
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,97524,192
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,97139,173
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,97101,79
+Regina,ORD-00294558_Regina_Summer_2025_GF_Digi,2096774,Food,2025-01-01,96717,30
+Saga,ORD-00284736 Saga Holiday_Dentsu_Skin+Standard_Jul24,1664796,Travel,2024-01-01,96549,112
+Pernod Ricard,ORD-00288374 _Direct_MGOMD_Pernod_Jameson_OF_Nov-Dec_LD,1821315,Alcohol,2024-01-01,96247,469
+Hays Travel,ORD-00295430 Hays Travel_ All Response_ Digital_ NCL_Aug,2092709,Travel,2025-01-01,95014,49
+The Royal Mint,ORD-00290615_RM_Xmas_2024_GF_OLI_DIGI ,1827231,Food,2024-01-01,95002,84
+The Royal Mint,ORD-00290615_Royal_Mint_Xmas_2024_GF_OLI_DIGI,1837608,Food,2024-01-01,95002,84
+Pernod Ricard,ORD-00282322_Direct_MGOMD_Pernod_AbsolutHunni_MayJune_LD,1613518,Alcohol,2024-01-01,94999,133
+Pernod Ricard,ORD-00282322_Direct_MGOMD_Pernod_AbsolutHunni_Pornstar Martini,1642215,Alcohol,2024-01-01,94999,133
+Regina,ORD-00294558_Regina_Summer_2025_GF_Digi,2096774,Food,2025-01-01,94788,41
+Morrisons,Morrisons_W/M_JulyUpweight,2060643,Supermarket,2025-01-01,94308,386
+Marti Pellow,ORD-00292425_ORD-00293305_Marti Pellow Live Nation Feb Dig 2025,1970990,Food,2025-01-01,94124,352
+Marti Pellow,ORD-00292425_ORD-00293305_Marti Pellow Live Nation Feb Dig 2025,1970990,Food,2025-01-01,94077,153
+Autoglym Perfect Partners,ORD-00284799 Autoglym_Perfect Partners_TG Digital_Jun/Jul 24,1661310,Motoring,2024-01-01,93761,79
+Jaguar Landrover,ORD-00299648_JLR x Top Gear Awards 2025,2277898,Motoring,2026-01-01,93489,32
+Jaguar Landrover,ORD-00299648_JLR x Top Gear Awards 2025,2277898,Motoring,2026-01-01,93261,82
+Norwegian Seafood ,ORD-00286656_Norwegian Seafood Q3/4 2024,1770504,Food,2024-01-01,92857,114
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,92756,20
+Birds Eye,ORD-00298551_Birds Eye Peas - Zenith - March - April,2277873,Food,2026-01-01,92294,2044
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,92107,126
+Carte D'Or,PG_Digi_Carte D'Or_Q2,1616515,Food,2024-01-01,91808,1030
+Apple,ORD-00289207 _Direct_Apple_MGOMD_RT_Disclaimers_Oct_LD,1863561,Entertainment,2024-01-01,91278,53
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,91025,52
+Dacia,ORD-00295503_Direct_Dacia_MGOMD_TG_Aug_LD,2089459,Motoring,2025-01-01,88985,1779
+Arla Lurpak,PG_Arla_LurpakPlant_Sept24,1789288,Food,2024-01-01,88894,887
+Piccolo,ORD-00293123 Piccolo_June_2025_GF_DIGI,2030423,Food,2025-01-01,88889,124
+Tom Kerridge,ORD-00281352_Cooks Britain_Tom Kerridge_TMC_GF TO_IMAud,1648697,Entertainment,2024-01-01,88884,1691
+Aldi,PG_Aldi_Valentines Day Feb,1907210,Food,2025-01-01,88507,1106
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,88096,303
+Jaguar Landrover,ORD-00299648_JLR x Top Gear Awards 2025,2277898,Motoring,2026-01-01,87105,34
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,87066,95
+Ruth Strauss Foundation,ORD-00294982 RSF x Immediate 2025,2141293,Health,2025-01-01,86960,84
+Merchant Gourmet,ORD-00291231_Merchant Gourmet_Yonder_Good Food_January 2025,1895723,Food,2025-01-01,86955,162
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,86844,98
+Beko,ORD-00293616_Beko_RunningTotal_GFKitchenvalue2025,1973988,Tech,2025-01-01,86349,36
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1962013,Motoring,2025-01-01,85066,75
+Brown Forman + El Jimador ,ORD-00289639 Brown Forman+El Jimador_Good Food_Christmas 2024,1812591,Alcohol,2024-01-01,84706,194
+Beko,ORD-00293616_Beko_RunningTotal_GFKitchenvalue2025,1973988,Tech,2025-01-01,84621,16
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,84089,0
+Aldi,ORD-00293735 & ORD-00293701_Aldi_May_2025,1995563,Supermarket,2025-01-01,84087,0
+Hays Travel - Feb,ORD-00292118 Hays Travel_ All Response_ Digital_ Ambassador_ 10.2,1918289,Travel,2025-01-01,84036,62
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,84012,59
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2026-01-01,83742,113
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,83684,856
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,83642,902
+The Walt Disney Company,Order_PG_Disney_Zenith_Hoppers,2259041,Entertainment,2026-01-01,83379,586
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,83349,201
+Pernod Ricard,ORD-00297666_PernodRicard_Absolut&Kahlua_December2025,2195115,Alcohol,2025-01-01,83347,294
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,83344,2903
+Aldi,PG_Aldi_December_Olive_GoodFood,2245377,Supermarket,2025-01-01,83343,31
+Aldi,PG_Aldi_December_Olive_GoodFood,2245377,Supermarket,2025-01-01,83341,22
+Tesco,ORD-00296514_Tesco Food Is Everything Oct 2025,2167250,Supermarket,2025-01-01,83336,14
+Tesco,ORD-00296514_Tesco Food Is Everything Oct 2025,2167250,Supermarket,2025-01-01,83331,6
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,83303,133
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,83298,3059
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,83281,164
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,83236,2895
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,83205,139
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,82656,95
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,82637,54
+Merchant Gourmet,ORD-00291231_Merchant Gourmet_Yonder_Good Food_January 2025,1895723,Food,2025-01-01,82146,163
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,81379,76
+Quickline Broadband,Quickline Broadband_ORD-00298403&ORD-00298567,2237189,Tech,2026-01-01,80601,2592
+Box,Box.co.uk/Norton_Digital Skin_December,2237872,Parenting,2025-01-01,80129,392
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,80083,53
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,80063,76
+Sold Out,ORD-00290662_SJM Peter Kay Online,1879912,Entertainment,2024-01-01,80002,96
+Nutracheck,Nutracheck,1856812,On-Demand,2024-01-01,79982,33
+Abarth,ORD-00295098_Abarth_600E_Q2_+_Q3_TG,2085940,Motoring,2025-01-01,79656,809
+Pernod Ricard,ORD-00297666 & ORD-00297808 _PernodRicard_Absolut&Kahlua_December2025,2206209,Alcohol,2025-01-01,79632,272
+Norwegian Seafood ,ORD-00286656_Norwegian Seafood Q3/4 2024,1770504,Food,2024-01-01,79528,73
+Warner Leisure,ORD-00278268 & ORD-00278274_Warner Leisure Hotels-Q4 2023 / Q1-2 2024,1510991,Travel,2024-01-01,78996,1597
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,78519,303
+Lidl,ORD-00288216_Direct_Lidl AppleandPears_sept24_LD,1768361,Supermarket,2024-01-01,78296,568
+Lidl,ORD-00288216_Direct_Lidl AppleandPears_sept24_LD (Correct),1761875,Supermarket,2024-01-01,78296,568
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,77621,58
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,77574,713
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,77555,665
+Centrum,ORD-00298340/ORD-00298146/ Centrum2026Partnership_Spark,2260270,Health,2026-01-01,77508,322
+Apple,ORD-00290658/ORD-00290661_Direct_Apple_Iphone14Pro RT_LPTO_Nov-Dec-LD,1869545,Entertainment,2024-01-01,77023,185
+Transport for Wales Rail,ORD-00289657_Transport For Wales: Kids Go Free,1815657,Travel,2024-01-01,76221,71
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,75993,47
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,75981,24
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,75556,267
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,75375,44
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,75278,39
+Birds Eye,ORD-00298551_Birds Eye Peas - Zenith - March - April,2277873,Food,2026-01-01,75193,330
+Visit Orlando,ORD-00295890 Visit Orlando Display,2161910,Travel,2025-01-01,75049,43
+Visit Orlando,ORD-00295890 Visit Orlando Display,2161910,Travel,2025-01-01,75042,18
+Visit Orlando,ORD-00295890 Visit Orlando Display,2161910,Travel,2025-01-01,75037,13
+Nacon,ORD-00287184 TestDriveUnlimited_IM_Gaming/TG/RT_Sept24,1830729,Gaming,2024-01-01,75007,52
+Visit Orlando,ORD-00295890 Visit Orlando Display,2161910,Travel,2025-01-01,75002,32
+Visit Orlando,ORD-00295890 Visit Orlando Display,2161910,Travel,2025-01-01,75000,37
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,74697,76
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,74585,655
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,74527,74
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,74013,66
+Nutracheck,Nutracheck,1856812,On-Demand,2024-01-01,72982,27
+Grana Padano,ORD-00284396_GRANA_PADANO_GF_COMPETITION_SUMMER24,1680625,Food,2024-01-01,72920,51
+Grana Padano,ORD-00284396_GRANA_PADANO_GF_COMPETITION_SUMMER24,1680625,Food,2024-01-01,72920,21
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,72872,131
+National Geographic,PG_Nat Geo_Zenith_David Blaine_24/03/25,1943612,Entertainment,2025-01-01,72800,225
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,72649,162
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,72518,529
+Warner Leisure,ORD-00278268 & ORD-00278274_Warner Leisure Hotels-Q4 2023 / Q1-2 2024,1510991,Travel,2024-01-01,72238,536
+Aldi,Aldi_Sept & Oct_Olive_GoodFood_Specially Selected,2108083,Supermarket,2025-01-01,71833,812
+Lidl,ORD-00290345_Direct_Lidl_OMD_Christmas_24_LD,1876516,Supermarket,2024-01-01,71519,691
+Diageo,ORD-00282260_ Diageo_Cocktail Widget_PHD_MarJun24,1604691,Alcohol,2024-01-01,71477,22
+Apple,ORD-00299603 _Direct_Apple_Marcom_ RT_March26,2288746,Entertainment,2026-01-01,71436,544
+Bloomsbury - Poppy Cooks,ORD-00287812_PoppyCooks_TMC_IMAud_GF OL_Aug24,1784624,Entertainment,2024-01-01,71432,38
+Toyota,PG_Toyota - Summer EV Range campaign 2024,1642790,Motoring,2024-01-01,71427,971
+Toyota,PG_Toyota - Summer EV Range campaign 2024,1642790,Motoring,2024-01-01,71425,945
+Bloomsbury - Poppy Cooks,ORD-00287812_PoppyCooks_TMC_IMAud_GF OL_Aug24,1784624,Entertainment,2024-01-01,71425,49
+Toyota,PG_Toyota - Summer EV Range campaign 2024,1642790,Motoring,2024-01-01,71425,1008
+Toyota,PG_Toyota - Summer EV Range campaign 2024,1642790,Motoring,2024-01-01,71422,714
+Apple,ORD-00299603 _Direct_Apple_Marcom_ RT_March26,2288746,Entertainment,2026-01-01,71415,994
+Apple,ORD-00299603 _Direct_Apple_Marcom_ RT_March26,2288746,Entertainment,2026-01-01,71372,580
+Renault,ORD-00296433_Renault_MGOMD_Renault 4_September-October25,2162513,Motoring,2025-01-01,71244,41
+Renault,ORD-00296433_Renault_MGOMD_Renault 4_September-October25,2162513,Motoring,2025-01-01,71242,49
+Bloomsbury - Poppy Cooks,ORD-00287812_PoppyCooks_TMC_IMAud_GF OL_Aug24,1784624,Entertainment,2024-01-01,71159,55
+Sold Out,ORD-00291953_Robbie Williams 2025 Q1 Digital,1903582,Entertainment,2025-01-01,70715,180
+Crowded House,ORD-00288821_Crowded House Sept-Oct,1780165,Entertainment,2024-01-01,70674,70
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1982913,Motoring,2025-01-01,70668,67
+Live Nation,ORD-00296088_Marti Pellow Live Nation - Sept 2025,2110358,Entertainment,2025-01-01,70616,15
+Sold Out,ORD-00291467_Robbie Williams (Metropolis) Digital Dec-Jan,1876366,Entertainment,2024-01-01,70614,139
+Crowded House,ORD-00288821_Crowded House Sept-Oct,1780165,Entertainment,2024-01-01,70610,41
+Sold Out,ORD-00291467_Robbie Williams (Metropolis) Digital Dec-Jan,1876366,Entertainment,2024-01-01,70594,192
+Sold Out,ORD-00291953_Robbie Williams 2025 Q1 Digital,1903582,Entertainment,2025-01-01,70590,167
+Live Nation,ORD-00296088_Marti Pellow Live Nation - Sept 2025,2110358,Entertainment,2025-01-01,70528,10
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,70372,124
+Toyota,PG_Toyota - Summer EV Range campaign 2024,1642790,Motoring,2024-01-01,70308,623
+Ruth Strauss Foundation,ORD-00294982 RSF x Immediate 2025,2141293,Health,2025-01-01,70093,24
+Hays Travel,ORD-00295430 Hays Travel_ All Response_ Digital_ NCL_Aug,2092709,Travel,2025-01-01,70012,16
+AA,ORD-00297226_AA_Digital Display Black Friday_19th Nov - 2nd Dec,2195460,Motoring,2025-01-01,70008,66
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,70008,33
+Hays Travel,ORD-00295430 Hays Travel_ All Response_ Digital_ NCL_Aug,2092709,Travel,2025-01-01,70006,26
+AA,ORD-00297226_AA_Digital Display Black Friday_19th Nov - 2nd Dec,2195460,Motoring,2025-01-01,70006,30
+AA,ORD-00297226_AA_Digital Display Black Friday_19th Nov - 2nd Dec,2195460,Motoring,2025-01-01,70004,47
+Ruth Strauss Foundation,ORD-00294982 RSF x Immediate 2025,2141293,Health,2025-01-01,69999,27
+Disney+,PG_Disney_Inside Out 2 EHV_Aug 24,1731379,Entertainment,2024-01-01,69874,553
+Aldi,ORD-00293735 & ORD-00293701_Aldi_May_2025,1995563,Supermarket,2025-01-01,68073,696
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,67511,4018
+CNIEL,ORD-00294404_CNIEL_2025_Oli_GF_Print_Digi_P2,2222649,Food,2025-01-01,67415,10
+CNIEL,ORD-00294404_CNIEL_2025_Oli_GF_Print_Digi_P2,2222649,Food,2025-01-01,67324,36
+ITV,ORD-00297090_BARTER ITV I'm A Celeb x Immediate Q4 2025,2171070,Supermarket,2025-01-01,66726,42
+ITV,ORD-00297090_BARTER ITV I'm A Celeb x Immediate Q4 2025,2171070,Supermarket,2025-01-01,66723,20
+ITV,ORD-00297090_BARTER ITV I'm A Celeb x Immediate Q4 2025,2171070,Supermarket,2025-01-01,66714,46
+Autoglym Perfect Partners,ORD-00284799 Autoglym_Perfect Partners_TG Digital_Jun/Jul 24,1661310,Motoring,2024-01-01,66672,22
+ITV,ORD-00297090_BARTER ITV I'm A Celeb x Immediate Q4 2025,2171070,Supermarket,2025-01-01,66672,35
+ITV,ORD-00297090_BARTER ITV I'm A Celeb x Immediate Q4 2025,2171070,Supermarket,2025-01-01,66661,56
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,66538,43
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,65869,413
+Transport for Wales Rail,ORD-00289657_Transport For Wales: Kids Go Free,1815657,Travel,2024-01-01,65717,119
+Kerrygold,ORD-00292017_Kerrygold_PHDManchester_partnership2025,1959016,Food,2025-01-01,65717,1323
+The Crown Estate,ORD-00295181_TCE FOF 25_RunningTotal_IMAud&MMA_AugSept25,2080345,Food,2025-01-01,65498,710
+Mattel UK,ORD-00283897 Hot Wheels_OneVue_2024 Digital - Phase 1,1652471,Motoring,2024-01-01,65316,717
+Apple,ORD-00289077Direct_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1792821,Entertainment,2024-01-01,65197,640
+Apple,ORD-00288652_ORD-00288653 _ORD-00289004__ ORD-00289077Direc t_Apple_MGOMD_RT_Marcomms_Sept_LD (IPhone),1863128,Entertainment,2024-01-01,65197,640
+Ticketmaster,ORD-00292992_Radio Times Network x Theatre Ticketmaster,1949498,Entertainment,2025-01-01,64629,121
+Ticketmaster,ORD-00292992_Radio Times Network x Theatre Ticketmaster,1949498,Entertainment,2025-01-01,64627,87
+Ticketmaster,ORD-00292992_Radio Times Network x Theatre Ticketmaster,1949498,Entertainment,2025-01-01,64618,95
+Pack'd,ORD-00298011_CB_Pack'd_GF_OL_Print_Digi_Feb25,2262769,Food,2026-01-01,64505,180
+Pack'd,ORD-00298011_CB_Pack'd_GF_OL_Print_Digi_Feb25,2262769,Food,2026-01-01,64484,12
+Pack'd,ORD-00298011_CB_Pack'd_GF_OL_Print_Digi_Feb25,2262769,Food,2026-01-01,64481,13
+Pack'd,ORD-00298011_CB_Pack'd_GF_OL_Print_Digi_Feb25,2262769,Food,2026-01-01,64473,28
+shell,ORD-00286771_Shell x Top Gear VPower,1733425,Motoring,2024-01-01,63336,26
+shell,ORD-00286771_Shell x Top Gear VPower,1733425,Motoring,2024-01-01,63334,11
+Diageo,ORD-00290180_Diageo_Christmas Cocktail Widget_PHD_Oct-Dec24,1888448,Alcohol,2024-01-01,63325,13
+Transport for Wales Rail,ORD-00289657_Transport For Wales: Kids Go Free,1815657,Travel,2024-01-01,63092,52
+Warner Hotels ,ORD-00297387 - Warner History weekends 2026,2254240,Entertainment,2026-01-01,63039,1925
+Linwoods,ORD-00295859_Direct_GF_Digital_Oct_Linwoods,2133969,Food,2025-01-01,62507,24
+River Street Events,ORD-00291522_RiverStreet_3shows_20thMarch30th August,2027374,Gardening,2025-01-01,62502,43
+Morrisons,ORD-00287596_Morrisons Christmas 2024_Wavemaker_Nov-Dec 24,1845134,Supermarket,2024-01-01,62501,61
+Linwoods,ORD-00295859_Direct_GF_Digital_Oct_Linwoods,2133969,Food,2025-01-01,62500,31
+Morrisons,ORD-00287596_Morrisons Christmas 2024_Wavemaker_Nov-Dec 24,1845134,Supermarket,2024-01-01,62441,67
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,62182,89
+Abarth,ORD-00295098_Abarth_600E_Q2_+_Q3_TG,2085940,Motoring,2025-01-01,62159,732
+Hays Travel - June ,ORD-00293796 hays Travel_ ARM_ Digital_ May,2020315,Travel,2025-01-01,62087,31
+Hays Travel - May,ORD-00293796 hays Travel_ ARM_ Digital_ May,2008529,Travel,2025-01-01,62087,31
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,61824,120
+Bletchley Park,ORD-00293045 Bletchley Park_April_Native_HE,2004503,Travel,2025-01-01,61801,161
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,61584,437
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,61496,72
+P&O Cruises,ORD-00299893_P&O Cruises BAFTA award promotion_Wavemaker_Mar-Apr26,2290174,Travel,2026-01-01,60821,4
+Hays Travel - June ,ORD-00293796 hays Travel_ ARM_ Digital_ May,2020315,Travel,2025-01-01,60578,52
+Hays Travel - June ,ORD-00293796 hays Travel_ ARM_ Digital_ May,2020315,Travel,2025-01-01,60558,12
+Hays Travel - May,ORD-00293796 hays Travel_ ARM_ Digital_ May,2008529,Travel,2025-01-01,60558,12
+Spode,ORD-00296824_Spode_Olive_Q4_2025_DIGI,2217950,Food,2025-01-01,60439,8
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,60202,49
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,60144,19
+The Royal Mint,ORD-00290615_Royal_Mint_Xmas_2024_GF_OLI_DIGI,1837608,Food,2024-01-01,60031,43
+Sold Out,ORD-00290662_SJM Peter Kay Online,1879912,Entertainment,2024-01-01,60004,56
+Playseat,ORD-00285484 Playseat_IM_TopGear_August,1731409,Gaming,2024-01-01,60001,117
+Sold Out,ORD-00290662_SJM Peter Kay Online,1879912,Entertainment,2024-01-01,60001,28
+Hays Travel - May,ORD-00293796 hays Travel_ ARM_ Digital_ May,2008529,Travel,2025-01-01,59991,21
+Hays Travel - June ,ORD-00293796 hays Travel_ ARM_ Digital_ May,2020315,Travel,2025-01-01,59990,21
+Sold Out,ORD-00290662_SJM Peter Kay Online,1879912,Entertainment,2024-01-01,59958,75
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,59286,50
+Norwegian Seafood ,ORD-00286656_Norwegian Seafood Q3/4 2024,1770504,Food,2024-01-01,59046,178
+St Ewe,ORD-00296431_XMAS_STEWE_2025,2225789,Food,2025-01-01,58874,27
+St Ewe,ORD-00296431_XMAS_STEWE_2025,2225789,Food,2025-01-01,58865,19
+Rare & Pasture,ORD-00295164_RARE & PASTURE: Digi_and_Print_2025,2145478,Food,2025-01-01,58848,8
+St Ewe,ORD-00296431_XMAS_STEWE_2025,2225789,Food,2025-01-01,58844,13
+St Ewe,ORD-00296431_XMAS_STEWE_2025,2225789,Food,2025-01-01,58843,16
+Regina,ORD-00295947_Regina_Sept_Digi_2025_OLI_GF,2118098,Food,2025-01-01,58839,9
+Rare & Pasture,ORD-00295164_RARE & PASTURE: Digi_and_Print_2025,2145478,Food,2025-01-01,58838,13
+Regina,ORD-00295947_Regina_Sept_Digi_2025_OLI_GF,2118098,Food,2025-01-01,58832,18
+Regina,ORD-00295947_Regina_Sept_Digi_2025_OLI_GF,2118098,Food,2025-01-01,58826,17
+Regina,ORD-00295947_Regina_Sept_Digi_2025_OLI_GF,2118098,Food,2025-01-01,58825,19
+Rare & Pasture,ORD-00295164_RARE & PASTURE: Digi_and_Print_2025,2145478,Food,2025-01-01,58791,22
+Rare & Pasture,ORD-00295164_RARE & PASTURE: Digi_and_Print_2025,2145478,Food,2025-01-01,58789,18
+Abarth,ORD-00293456_Abarth 600E_Q2_TG,1974081,Motoring,2025-01-01,58741,571
+Playseat,ORD-00285484 Playseat_IM_TopGear_August,1731409,Gaming,2024-01-01,58522,2648
+Lidl,ORD-00292527_Direct_Lidl_Fresh_FebMarch25_LD,1981602,Food,2025-01-01,58004,517
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,57858,313
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,57856,234
+Cost Cutter,ORD-00291366 Costcutter_ Boutique_ Alpro_ Digital_ jan 25,1893445,Food,2025-01-01,57740,87
+bet365,ORD-00284541_bet365 Euro 2024 Package,1685101,Gambling,2024-01-01,57662,1050
+Cupra,ORD-00292435 & ORD-00292441_Cupra_PHD_Formentor&BornCampaign_24-25,1945352,Motoring,2025-01-01,57605,399
+Piccolo,ORD-00281699_Piccolo_May_Jun'24_Digi_GF,1654527,Food,2024-01-01,57502,26
+Piccolo,ORD-00281699_Piccolo_May_Jun'24_Digi_GF,1654527,Food,2024-01-01,57501,56
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,56953,36
+Diageo,Johnnie Walker Partnership_Diageo_PHD_AprilJune25,1974104,Alcohol,2025-01-01,56470,1087
+Warner Leisure,ORD-00278268 & ORD-00278274_Warner Leisure Hotels-Q4 2023 / Q1-2 2024,1510991,Travel,2024-01-01,56416,446
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,56000,8
+National Geographic,PG_Nat Geo: Defending Europe_RT History Sep,1760336,Entertainment,2024-01-01,55835,583
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,55630,584
+Currys Blink,ORD-00297416_Currys/Blink_Affiliates_Q4 Campaign_RT,2229893,Entertainment,2025-01-01,55626,22
+Mattel UK,ORD-00283897 Hot Wheels_OneVue_2024 Digital - Phase 1,1652471,Motoring,2024-01-01,55608,522
+Currys Blink,ORD-00297416_Currys/Blink_Affiliates_Q4 Campaign_RT,2229893,Entertainment,2025-01-01,55565,42
+Disney+,PG_Disney_Inside Out 2 EHV_Aug 24,1731379,Entertainment,2024-01-01,55553,405
+Currys Blink,ORD-00297416_Currys/Blink_Affiliates_Q4 Campaign_RT,2229893,Entertainment,2025-01-01,55490,74
+AA,ORD-00297226_AA_Digital Display Black Friday_19th Nov - 2nd Dec,2195460,Motoring,2025-01-01,55455,19
+Linwoods,ORD-00284284_Linwoods_July_2024_GF_Print_Digi,1702181,Food,2024-01-01,55288,21
+Linwoods,ORD-00284284_Linwoods_July_2024_GF_Print_Digi,1702181,Food,2024-01-01,55281,30
+Linwoods,ORD-00284284_Linwoods_July_2024_GF_Print_Digi,1702181,Food,2024-01-01,55280,74
+Linwoods,ORD-00284284_Linwoods_July_2024_GF_Print_Digi,1702181,Food,2024-01-01,55279,56
+Linwoods,ORD-00284284_Linwoods_July_2024_GF_Print_Digi,1702181,Food,2024-01-01,55278,97
+Saga,ORD-00284736 Saga Holiday_Dentsu_Skin+Standard_Jul24,1664796,Travel,2024-01-01,55021,43
+Regina,ORD-00284249_Regina_Summer2024_GF_DEL_Digi_Print,1698446,Food,2024-01-01,55006,27
+Live Nation,ORD-00286536_Crowded House July-August 2024,1718403,Entertainment,2024-01-01,55001,87
+Alpen,ORD-00277683_Alpen_GetMeMedia_Nov-Sept,1601248,Food,2024-01-01,54758,66
+Mattel UK,ORD-00283897 Hot Wheels_OneVue_2024 Digital - Phase 1,1652471,Motoring,2024-01-01,54655,462
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,54655,511
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,54649,663
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,54310,322
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,54283,691
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,54276,300
+Hays Travel - Feb,ORD-00292118 Hays Travel_ All Response_ Digital_ Ambassador_ 10.2,1918289,Travel,2025-01-01,54104,27
+Hays Travel - Feb,ORD-00292118 Hays Travel_ All Response_ Digital_ Ambassador_ 10.2,1918289,Travel,2025-01-01,54099,32
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,53998,10
+Uzbekistan Travel,ORD-00297052_Direct_Digi_Uzbekistan Q4 2025,2199814,Travel,2025-01-01,53091,45
+Bisodol,ORD-00293989 Bisodol_ Cornerstone_ GF_ print digi,2059527,Food,2025-01-01,52833,15
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,52721,33
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,52548,1134
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,52539,937
+De'Longhi,ORD-00287830_De'Longhi_Auto_H2_24,1785826,Food,2024-01-01,52536,626
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,52505,2131
+bet365,ORD-00298020_bet365 H1 2026,2238101,Gambling,2026-01-01,52456,11
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,52421,529
+Ristorante,ORD-00294283_Ristorante_WM_partnership_July-Sept2025,2069878,Food,2025-01-01,52140,465
+Jaguar Landrover,ORD-00299648_JLR x Top Gear Awards 2025,2277898,Motoring,2026-01-01,51648,16
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,51599,44
+The Royal Mint,ORD-00290615_RM_Xmas_2024_GF_OLI_DIGI ,1827231,Food,2024-01-01,51532,40
+Jaguar Landrover,ORD-00299648_JLR x Top Gear Awards 2025,2277898,Motoring,2026-01-01,51527,58
+Diageo,Diageo_JohnnieWalkerBlack_Sep-Dec (Native),1817891,Alcohol,2024-01-01,51447,705
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,51405,67
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,51300,384
+Hays OctNov,ORD-00290117 Hays Travel_ All Response_ Digital_ 28/10,1811607,Travel,2024-01-01,51284,63
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,51284,59
+Hays OctNov,ORD-00290117 Hays Travel_ All Response_ Digital_ 28/10,1811607,Travel,2024-01-01,51284,40
+Hays OctNov,ORD-00290117 Hays Travel_ All Response_ Digital_ 28/10,1811607,Travel,2024-01-01,51284,130
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,51283,51
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,51283,134
+Mattel UK,ORD-00283897 Hot Wheels_OneVue_2024 Digital - Phase 1,1652471,Motoring,2024-01-01,51266,290
+Live Nation,ORD-00293107_Live Nation - Stevie Wonder Digital,1946115,Entertainment,2025-01-01,50985,57
+Hurtigruten,Hurtigruten Sale Activity Dec and Jan,2245994,Travel,2025-01-01,50776,35
+Inspired Villages Group Limited,ORD-00284044_Inspired Villages Soap Awards,1701686,Entertainment,2024-01-01,50177,50
+Asda,ORD-00290869 Direct - Asda_Spark_Christmas 2024,1870866,Food,2024-01-01,50085,38
+David Essex,ORD-00296950_David Essex (SJM) - October/November 2025,2229834,Entertainment,2025-01-01,50034,44
+Hays Travel - June ,ORD-00293796 hays Travel_ ARM_ Digital_ May,2020315,Travel,2025-01-01,50028,27
+Asda,ORD-00290869 Direct - Asda_Spark_Christmas 2024,1870866,Food,2024-01-01,50027,37
+David Essex,ORD-00296950_David Essex (SJM) - October/November 2025,2229834,Entertainment,2025-01-01,50024,24
+Princess Cruises ,ORD-00277435_Princess 24 partnership_7 STars_Dec-May,1525755,Travel,2024-01-01,50021,4
+Regina,ORD-00284249_Regina_Summer2024_GF_DEL_Digi_Print,1698446,Food,2024-01-01,50020,15
+Asda,ORD-00290869 Direct - Asda_Spark_Christmas 2024,1870866,Food,2024-01-01,50015,26
+Windsor Castle,ORD-00293267_Windsor Castle - June to August 2025,2094137,History,2025-01-01,50015,720
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,50011,44
+Nutracheck,Nutracheck 2026,2231196,Health,2025-01-01,50010,223
+shell,ORD-00294734_Shell F1 x Top Gear 2025,2071034,On-Demand,2025-01-01,50009,31
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,50008,223
+The Royal Mint,ORD-00290615_Royal_Mint_Xmas_2024_GF_OLI_DIGI,1837608,Food,2024-01-01,50006,18
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,50006,78
+The Royal Mint,ORD-00290615_RM_Xmas_2024_GF_OLI_DIGI ,1827231,Food,2024-01-01,50006,18
+Winalot,Winalot 2024_OpenMind_WPP,1647224,Pets,2024-01-01,50005,37
+The Royal Mint,ORD-00290615_Royal_Mint_Xmas_2024_GF_OLI_DIGI,1837608,Food,2024-01-01,50005,44
+The Royal Mint,ORD-00290615_RM_Xmas_2024_GF_OLI_DIGI ,1827231,Food,2024-01-01,50005,44
+The Walt Disney Company,Order_PG_Disney_Zenith_Hoppers,2259041,Entertainment,2026-01-01,50005,279
+Nacon,ORD-00287184 TestDriveUnlimited_IM_Gaming/TG/RT_Sept24,1830729,Gaming,2024-01-01,50004,447
+Nutracheck,Nutracheck 2026,2231196,Health,2025-01-01,50003,1284
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,50002,1284
+David Essex,ORD-00296950_David Essex (SJM) - October/November 2025,2229834,Entertainment,2025-01-01,50002,64
+The Royal Mint,ORD-00290615_RM_Xmas_2024_GF_OLI_DIGI ,1827231,Food,2024-01-01,50002,37
+The Royal Mint,ORD-00290615_Royal_Mint_Xmas_2024_GF_OLI_DIGI,1837608,Food,2024-01-01,50000,20
+The Royal Mint,ORD-00290615_Royal_Mint_Xmas_2024_GF_OLI_DIGI,1837608,Food,2024-01-01,50000,88
+The Royal Mint,ORD-00290615_Royal_Mint_Xmas_2024_GF_OLI_DIGI,1837608,Food,2024-01-01,50000,37
+The Royal Mint,ORD-00290615_Royal_Mint_Xmas_2024_GF_OLI_DIGI,1837608,Food,2024-01-01,50000,43
+Regina,ORD-00284249_Regina_Summer2024_GF_DEL_Digi_Print,1698446,Food,2024-01-01,50000,28
+The Royal Mint,ORD-00290615_RM_Xmas_2024_GF_OLI_DIGI ,1827231,Food,2024-01-01,50000,43
+David Austin Roses,ORD-00281749 /David Austin Roses/Gardeners World May-June24,1648517,Gardening,2024-01-01,50000,24
+Regina,ORD-00284249_Regina_Summer2024_GF_DEL_Digi_Print,1698446,Food,2024-01-01,50000,33
+BioGaia,ORD-00294424_BioGaia 2025 £10k Video MFMs Campaign,2142659,Parenting,2025-01-01,50000,15
+The Royal Mint,ORD-00290615_RM_Xmas_2024_GF_OLI_DIGI ,1827231,Food,2024-01-01,49999,20
+The Royal Mint,ORD-00290615_RM_Xmas_2024_GF_OLI_DIGI ,1827231,Food,2024-01-01,49997,87
+Kerrygold,ORD-00292017_Kerrygold_PHDManchester_partnership2025,1959016,Food,2025-01-01,49991,158
+AA,ORD-00295080_AA_Net Rev_Digital Display_20/07/25,2080159,Motoring,2025-01-01,49990,4
+National Geographic,PG_Nat Geo_Zenith_David Blaine_24/03/25,1943612,Entertainment,2025-01-01,49972,869
+Life Health Foods,ORD-00292201_LHF_StirPR_MFM_2025,2022775,Parenting,2025-01-01,49970,24
+Life Health Foods,ORD-00292201_LHF_StirPR_MFM_2025,2022775,Parenting,2025-01-01,49966,60
+AA,ORD-00295080_AA_Net Rev_Digital Display_20/07/25,2080159,Motoring,2025-01-01,49953,30
+National Geographic,PG_Nat Geo_Zenith_David Blaine_24/03/25,1943612,Entertainment,2025-01-01,49949,359
+Bletchley Park,ORD-00281879_Bletchley Park_Grove media_April_History,1657730,History,2024-01-01,49894,120
+shell,ORD-00286771_Shell x Top Gear VPower,1733425,Motoring,2024-01-01,49857,20
+Aldi,ORD-00295386_Direct_Aldi_August_Digi_2025,2080311,Supermarket,2025-01-01,49797,794
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,49765,28
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,49749,16
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,49749,19
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,49748,16
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,49618,21
+River Street Events,River Street Events Ltd _GW_Events_-_Digi_promo,1621866,Gardening,2024-01-01,49559,20
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,49108,40
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,49000,172
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,48923,54
+Quickline Broadband,Quickline Broadband_ORD-00298403&ORD-00298567,2237189,Tech,2026-01-01,48358,1339
+Jaguar Landrover,ORD-00299648_JLR x Top Gear Awards 2025,2277898,Motoring,2026-01-01,48269,9
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,48001,272
+Pernod Ricard,ORD-00297666_PernodRicard_Absolut&Kahlua_December2025,2195115,Alcohol,2025-01-01,47731,25
+Pernod Ricard,ORD-00297666 & ORD-00297808 _PernodRicard_Absolut&Kahlua_December2025,2206209,Alcohol,2025-01-01,47728,25
+Bloomsbury - Jon Watts,ORD-00287811_JonWatts Speedy_TMC_IMAud_GF OL_Aug24,1740281,Entertainment,2024-01-01,47622,16
+Bloomsbury - Jon Watts,ORD-00287811_JonWatts Speedy_TMC_IMAud_GF OL_Aug24,1740281,Entertainment,2024-01-01,47619,14
+Bloomsbury - Jon Watts,ORD-00287811_JonWatts Speedy_TMC_IMAud_GF OL_Aug24,1740281,Entertainment,2024-01-01,47607,22
+Waitrose,ORD-00293374_Direct_Waitrose_MGOMD_Easter25_LD,1969303,Supermarket,2025-01-01,47486,412
+Live Nation,ORD-00291273_Marti Pellow Live Nation December ,1875495,Entertainment,2024-01-01,47102,45
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,47090,339
+Ticketmaster,ORD-00291153_Premium Theatre Ticketmaster December Digital,1864658,Entertainment,2024-01-01,47086,97
+Ticketmaster,ORD-00290285_Ticketmaster Q4 Digital,1812615,Entertainment,2024-01-01,47077,92
+Marti Pellow,ORD-00292425_ORD-00293305_Marti Pellow Live Nation Feb Dig 2025,1970990,Food,2025-01-01,47073,42
+Ticketmaster,ORD-00290285_Ticketmaster Q4 Digital,1812615,Entertainment,2024-01-01,47061,111
+Live Nation,ORD-00291273_Marti Pellow Live Nation December ,1875495,Entertainment,2024-01-01,47061,125
+Marti Pellow,ORD-00291806_Marti Pellow Live Nation January Dig 2025,1908256,Entertainment,2025-01-01,47061,104
+Live Nation,ORD-00293268_John Legend Live Nation Dig March-April,1963295,Entertainment,2025-01-01,47060,130
+Ticketmaster,ORD-00291153_Premium Theatre Ticketmaster December Digital,1864658,Entertainment,2024-01-01,47059,51
+Live Nation,ORD-00293268_John Legend Live Nation Dig March-April,1963295,Entertainment,2025-01-01,47058,51
+Marti Pellow,ORD-00291806_Marti Pellow Live Nation January Dig 2025,1908256,Entertainment,2025-01-01,47047,85
+Marti Pellow,ORD-00292425_ORD-00293305_Marti Pellow Live Nation Feb Dig 2025,1970990,Food,2025-01-01,47047,52
+Spode,ORD-00296824_Spode_Olive_Q4_2025_DIGI,2217950,Food,2025-01-01,46323,15
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,45887,71
+Pernod Ricard,ORD-00297666_PernodRicard_Absolut&Kahlua_December2025,2195115,Alcohol,2025-01-01,45665,45
+Pernod Ricard,ORD-00297666 & ORD-00297808 _PernodRicard_Absolut&Kahlua_December2025,2206209,Alcohol,2025-01-01,45661,45
+Sainsburys,ORD-00294588_Sainsbury's x Good Food TTD P2 June-August,2045562,Supermarket,2025-01-01,45602,505
+Immediate Media,Marketing - The Good Food Show,1631040,Food,2024-01-01,45124,19
+Immediate Media,Marketing - GF-Good Food Show,1627372,Food,2024-01-01,45124,19
+Hays Travel - June ,ORD-00293796 hays Travel_ ARM_ Digital_ May,2020315,Travel,2025-01-01,45037,22
+Regina,ORD-00284249_Regina_Summer2024_GF_DEL_Digi_Print,1698446,Food,2024-01-01,45020,15
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,44843,137
+Sarson's,ORD-00296250_ Direct-Sarson's_Bicycle_Repurposed Native_October 2025,2153107,Food,2025-01-01,44752,235
+If You Care,ORD-00287017_IFC_Sept/Oct_GFOLI_DIGI,1823356,Food,2024-01-01,44455,10
+If You Care,ORD-00287017_IFC_Sept/Oct_GFOLI_DIGI,1823356,Food,2024-01-01,44449,13
+If You Care,ORD-00287017_IFC_Sept/Oct_GFOLI_DIGI,1823356,Food,2024-01-01,44444,40
+If You Care,ORD-00287017_IFC_Sept/Oct_GFOLI_DIGI,1823356,Food,2024-01-01,44442,22
+If You Care,ORD-00287017_IFC_Sept/Oct_GFOLI_DIGI,1823356,Food,2024-01-01,44430,36
+If You Care,ORD-00287017_IFC_Sept/Oct_GFOLI_DIGI,1823356,Food,2024-01-01,44344,24
+CNIEL,ORD-00294069/CNIEL_2025_Oli_GF_Print_Digi,2053910,Food,2025-01-01,44122,16
+CNIEL,ORD-00294069/CNIEL_2025_Oli_GF_Print_Digi,2053910,Food,2025-01-01,44119,12
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,44038,339
+Apple,ORD-00288525_Direct_Apple_MGOMD_RT_Wolfs_Sept_LD,1768307,Entertainment,2024-01-01,44038,1116
+Piccolo,ORD-00281699_Piccolo_May_Jun'24_Digi_GF,1654527,Food,2024-01-01,43753,10
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,43349,27
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,42501,268
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,41764,44
+shell,ORD-00286771_Shell x Top Gear VPower,1733425,Motoring,2024-01-01,41333,8
+Merchant Gourmet,ORD-00291231_Merchant Gourmet_Yonder_Good Food_January 2025,1895723,Food,2025-01-01,40069,34
+Saga,ORD-00284736 Saga Holiday_Dentsu_Skin+Standard_Jul24,1664796,Travel,2024-01-01,40023,16
+Sold Out,ORD-00290964_Direct -Aussie Pink Floyd,1875507,Entertainment,2024-01-01,40003,40
+Sold Out,ORD-00290964_Direct -Aussie Pink Floyd,1875507,Entertainment,2024-01-01,40002,30
+Sold Out,ORD-00290964_Direct -Aussie Pink Floyd,1875507,Entertainment,2024-01-01,40001,71
+Sold Out,ORD-00290964_Direct -Aussie Pink Floyd,1875507,Entertainment,2024-01-01,40001,117
+Sold Out,ORD-00290964_Direct -Aussie Pink Floyd,1875507,Entertainment,2024-01-01,40001,51
+The Royal Mint,ORD-00290615_Royal_Mint_Xmas_2024_GF_OLI_DIGI,1837608,Food,2024-01-01,40000,34
+Aldi,Aldi_Christmas_25,2175479,Supermarket,2025-01-01,40000,47
+Playseat,ORD-00285484 Playseat_IM_TopGear_August,1731409,Gaming,2024-01-01,39999,90
+River Street Events,River Street Events Ltd _GW_Events_-_Digi_promo,1621866,Gardening,2024-01-01,39643,25
+If You Care,ORD-00283392_If You Care_Spring_Campaign_May2024_digi_GF,1661577,Food,2024-01-01,39500,25
+If You Care,ORD-00283392_If You Care_Spring_Campaign_May2024_digi_GF,1661577,Food,2024-01-01,39500,20
+Diageo,ORD-00288038_(Diageo) Casamigos_Repurposed_PHD_July24June25,1777213,Alcohol,2024-01-01,39462,228
+AMEX,PG_AMEX_IPG Kinesso_H1 Gold & Platinum_18/03-26/05/26_RT,2289056,Finance,2026-01-01,39332,837
+Grana Padano,ORD-00284396_GRANA_PADANO_GF_COMPETITION_SUMMER24,1680625,Food,2024-01-01,39088,20
+Grana Padano,ORD-00284396_GRANA_PADANO_GF_COMPETITION_SUMMER24,1680625,Food,2024-01-01,39088,2
+Grana Padano,ORD-00284396_GRANA_PADANO_GF_COMPETITION_SUMMER24,1680625,Food,2024-01-01,39087,28
+Grana Padano,ORD-00284396_GRANA_PADANO_GF_COMPETITION_SUMMER24,1680625,Food,2024-01-01,39087,26
+Grana Padano,ORD-00284396_GRANA_PADANO_GF_COMPETITION_SUMMER24,1680625,Food,2024-01-01,39087,45
+Merchant Gourmet,ORD-00291231_Merchant Gourmet_Yonder_Good Food_January 2025,1895723,Food,2025-01-01,39076,30
+Suma Wholefoods,ORD-00290557 _Suma Wholefoods Digital Campaign Q1  2025,1894454,Food,2025-01-01,38500,111
+Disney+,PG_Digital_Disney_Zenith_InsideOut2MayJun-2024,1639286,Entertainment,2024-01-01,38423,364
+Lidl,ORD-00289956_LidlDeluxeChristmas2024_OMD_Oct-Dec,1837113,Food,2024-01-01,38407,34
+Sarson's,ORD-00294257_Direct - Sarsons_Bicycle_Summer_2025_July_Good Food Olive,2042785,Food,2025-01-01,38113,175
+AMEX,PG_AMEX_IPG Kinesso_H1 Gold & Platinum_18/03-26/05/26_RT,2289056,Finance,2026-01-01,38075,821
+Aldi,ORD-00299514_Direct_AldiEaster2026,2271794,Supermarket,2026-01-01,37829,468
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,37776,134
+Suma Wholefoods,ORD-00290557 _Suma Wholefoods Digital Campaign Q1  2025,1894454,Food,2025-01-01,37513,42
+Haier,ORD-00283019_Haier_Jun_GF_2024_Digi,1683636,Food,2024-01-01,37502,6
+If You Care,ORD-00283392_If You Care_Spring_Campaign_May2024_digi_GF,1661577,Food,2024-01-01,37502,13
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1669752,Alcohol,2024-01-01,37501,10
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1667821,Alcohol,2024-01-01,37501,10
+Haier,ORD-00283019_Haier_Jun_GF_2024_Digi,1683636,Food,2024-01-01,37500,30
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1667821,Alcohol,2024-01-01,37500,17
+Haier,ORD-00283019_Haier_Jun_GF_2024_Digi,1683636,Food,2024-01-01,37500,3
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1667821,Alcohol,2024-01-01,37500,22
+Haier,ORD-00283019_Haier_Jun_GF_2024_Digi,1683636,Food,2024-01-01,37500,12
+Haier,ORD-00283019_Haier_Jun_GF_2024_Digi,1683636,Food,2024-01-01,37500,6
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1669752,Alcohol,2024-01-01,37500,17
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1669752,Alcohol,2024-01-01,37500,22
+Suma Wholefoods,ORD-00290557 _Suma Wholefoods Digital Campaign Q1  2025,1894454,Food,2025-01-01,37500,31
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1667821,Alcohol,2024-01-01,37491,27
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1669752,Alcohol,2024-01-01,37491,27
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1669752,Alcohol,2024-01-01,37479,39
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1667821,Alcohol,2024-01-01,37479,39
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,37146,88
+Suma Wholefoods,ORD-00290557 _Suma Wholefoods Digital Campaign Q1  2025,1894454,Food,2025-01-01,37012,19
+Suma Wholefoods,ORD-00290557 _Suma Wholefoods Digital Campaign Q1  2025,1894454,Food,2025-01-01,37001,27
+Merchant Gourmet,ORD-00291231_Merchant Gourmet_Yonder_Good Food_January 2025,1895723,Food,2025-01-01,37001,14
+Sarson's,ORD-00288776_Sarsons Vinegar_Brewed for Food Burst 2_Food_Sep24,1789636,Food,2024-01-01,36828,127
+Sold Out,ORD-00290662_SJM Peter Kay Online,1879912,Entertainment,2024-01-01,36167,129
+Cost Cutter,ORD-00291366 Costcutter_ Boutique_ Alpro_ Digital_ jan 25,1893445,Food,2025-01-01,36012,28
+Sold Out,ORD-00290685_Bonnie Raitt AEG_Nov 24,1879809,Entertainment,2024-01-01,35855,26
+Centrum,ORD-00291473_Centrum_Spark_Vitamins 2025,1896853,Health,2025-01-01,35827,567
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,35516,143
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,35515,247
+If You Care,ORD-00283392_If You Care_Spring_Campaign_May2024_digi_GF,1661577,Food,2024-01-01,35509,8
+If You Care,ORD-00283392_If You Care_Spring_Campaign_May2024_digi_GF,1661577,Food,2024-01-01,35502,12
+Angelcare,ORD-00287020_Angelcare Made For Mums 2024,1791084,Parenting,2024-01-01,35002,13
+Thames and Hudson // D-Day Atlas - Charles Messenger,ORD-00283523 D-Day Atlas_Thames&Hudson_Total_May/June_H,1647175,Entertainment,2024-01-01,35001,54
+The Baby Show,ORD-00284360_The Baby Show Manchester Solus and Takeover,1657660,Parenting,2024-01-01,35000,324
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,34866,34
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,34785,7814
+Audible,Audible_wavemaker_Comedy_July25,2054149,Entertainment,2025-01-01,34601,0
+Norwegian Seafood ,ORD-00286656_Norwegian Seafood Q3/4 2024,1770504,Food,2024-01-01,34523,34
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,34468,30
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,34078,31
+The Crown Estate,ORD-00284347_The Crown Estate - GW 2024 Campaign,1680347,Parenting,2024-01-01,34032,38
+Bloomsbury,ORD-00296570 Bloomsbury Display & Solus,2193064,Entertainment,2025-01-01,34028,82
+Outfit 7 - Hank Anniversary ,ORD-00289827 Hank anniversary _IM_RT-Q4AV,1860020,Gaming,2024-01-01,34005,54
+Warner Leisure,ORD-00278268 & ORD-00278274_Warner Leisure Hotels-Q4 2023 / Q1-2 2024,1510991,Travel,2024-01-01,33853,326
+Outfit 7 - Hank Anniversary ,ORD-00289827 Hank anniversary _IM_RT-Q4AV,1860020,Gaming,2024-01-01,33424,30
+Waitrose,ORD-00289156_Direct_Waitrose_MGOMD_No.1_Oct_LD,1781537,Supermarket,2024-01-01,33386,153
+Piccolo,ORD-00293123 Piccolo_June_2025_GF_DIGI,2030423,Food,2025-01-01,33368,6
+Piccolo,ORD-00293123 Piccolo_June_2025_GF_DIGI,2030423,Food,2025-01-01,33360,12
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,33356,376
+Outfit 7 - Hank Anniversary ,ORD-00289827 Hank anniversary _IM_RT-Q4AV,1860020,Gaming,2024-01-01,33347,29
+Piccolo,ORD-00293123 Piccolo_June_2025_GF_DIGI,2030423,Food,2025-01-01,33339,11
+The Walt Disney Company,Order_PG_Disney_Zenith_Hoppers,2259041,Entertainment,2026-01-01,33337,328
+Piccolo,ORD-00293123 Piccolo_June_2025_GF_DIGI,2030423,Food,2025-01-01,33335,30
+Sold Out,ORD-00289070_Billy Ocean Sept-Oct 2024,1875608,Entertainment,2024-01-01,33333,55
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,33231,7
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,33215,68
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,33205,86
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,33204,87
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,33204,48
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,33202,24
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,33197,18
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,33195,28
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,33179,28
+Carte D'Or,ORD-00297006 Direct_Digi_Carte D'Or_Q4 2025,2174656,Food,2025-01-01,33168,2158
+Sold Out,ORD-00289070_Billy Ocean Sept-Oct 2024,1875608,Entertainment,2024-01-01,33150,66
+The Royal Mint,ORD-00290615_RM_Xmas_2024_GF_OLI_DIGI ,1827231,Food,2024-01-01,32129,27
+The Royal Mint,ORD-00294117 The Royal Mint_Four Agency_History_Royalty,2224949,Entertainment,2025-01-01,32000,23
+The Royal Mint,ORD-00294117 The Royal Mint_Four Agency_History_Royalty,2224949,Entertainment,2025-01-01,31995,11
+The Royal Mint,ORD-00294117 The Royal Mint_Four Agency_History_Royalty,2224949,Entertainment,2025-01-01,31993,25
+The Royal Mint,ORD-00294117 The Royal Mint_Four Agency_History_Royalty,2224949,Entertainment,2025-01-01,31960,30
+The Royal Mint,ORD-00294117 The Royal Mint_Four Agency_History_Royalty,2224949,Entertainment,2025-01-01,31941,32
+Kikkoman,ORD-00290623_Digi_Display_Xmas'24_GF,1856776,Food,2024-01-01,31784,11
+Kikkoman,ORD-00290623_Digi_Display_Xmas'24_GF,1856776,Food,2024-01-01,31778,11
+Kikkoman,ORD-00290623_Digi_Display_Xmas'24_GF,1856776,Food,2024-01-01,31753,20
+Kikkoman,ORD-00290623_Digi_Display_Xmas'24_GF,1856776,Food,2024-01-01,31748,34
+Kikkoman,ORD-00290623_Digi_Display_Xmas'24_GF,1856776,Food,2024-01-01,31748,30
+AA,ORD-00297226_AA_Digital Display Black Friday_19th Nov - 2nd Dec,2195460,Motoring,2025-01-01,31183,11
+Sold Out,ORD-00289070_Billy Ocean Sept-Oct 2024,1875608,Entertainment,2024-01-01,30940,76
+Pernod Ricard,ORD-00297666_PernodRicard_Absolut&Kahlua_December2025,2195115,Alcohol,2025-01-01,30362,20
+Pernod Ricard,ORD-00297666 & ORD-00297808 _PernodRicard_Absolut&Kahlua_December2025,2206209,Alcohol,2025-01-01,30361,20
+Hays Travel - June ,ORD-00293796 hays Travel_ ARM_ Digital_ May,2020315,Travel,2025-01-01,30033,8
+Hays Travel - June ,ORD-00293796 hays Travel_ ARM_ Digital_ May,2020315,Travel,2025-01-01,30019,11
+BioGaia,ORD-00294424_BioGaia 2025 £10k Video MFMs Campaign,2142659,Parenting,2025-01-01,30001,8
+BioGaia,ORD-00294424_BioGaia 2025 £10k Video MFMs Campaign,2142659,Parenting,2025-01-01,30000,17
+Norwegian Seafood ,ORD-00286656_Norwegian Seafood Q3/4 2024,1770504,Food,2024-01-01,30000,13
+Piccolo,ORD-00281699_Piccolo_May_Jun'24_Digi_GF,1654527,Food,2024-01-01,30000,4
+Piccolo,ORD-00281699_Piccolo_May_Jun'24_Digi_GF,1654527,Food,2024-01-01,30000,10
+Long Clawson,ORD-00283654_1912_May_June'24_Email_DigiDisplay_Long Clawson,1661119,Food,2024-01-01,29999,15
+BioGaia,ORD-00294424_BioGaia 2025 £10k Video MFMs Campaign,2142659,Parenting,2025-01-01,29999,28
+Long Clawson,ORD-00283654_1912_May_June'24_Email_DigiDisplay_Long Clawson,1661119,Food,2024-01-01,29999,10
+BioGaia,ORD-00294424_BioGaia 2025 £10k Video MFMs Campaign,2142659,Parenting,2025-01-01,29989,0
+Hays Travel - June ,ORD-00294354 Hays Travel_ ARM_ Digital_ Ambassador_ june,2034225,Travel,2025-01-01,29989,12
+BioGaia,ORD-00294424_BioGaia 2025 £10k Video MFMs Campaign,2142659,Parenting,2025-01-01,29979,3
+Pernod Ricard,ORD-00297666 & ORD-00297808 _PernodRicard_Absolut&Kahlua_December2025,2206209,Alcohol,2025-01-01,29327,16
+Pernod Ricard,ORD-00297666_PernodRicard_Absolut&Kahlua_December2025,2195115,Alcohol,2025-01-01,29327,16
+Sarson's,ORD-00288776_Sarsons Vinegar_Brewed for Food Burst 2_Food_Sep24,1789636,Food,2024-01-01,29219,2549
+Diageo,Johnnie Walker Partnership_Diageo_PHD_AprilJune25,1974104,Alcohol,2025-01-01,28942,4994
+Itsu ,ORD-00287826_Direct - Itsu_Yonder_Summer Brief_Sept 2024,1748340,Food,2024-01-01,28403,204
+Spode,ORD-00296824_Spode_Olive_Q4_2025_DIGI,2217950,Food,2025-01-01,28338,18
+Live Nation,ORD-00293107_Live Nation - Stevie Wonder Digital,1946115,Entertainment,2025-01-01,28266,22
+Live Nation,ORD-00293107_Live Nation - Stevie Wonder Digital,1946115,Entertainment,2025-01-01,28246,44
+Live Nation,ORD-00293107_Live Nation - Stevie Wonder Digital,1946115,Entertainment,2025-01-01,28239,92
+Live Nation,ORD-00293107_Live Nation - Stevie Wonder Digital,1946115,Entertainment,2025-01-01,28236,52
+Live Nation,ORD-00293107_Live Nation - Stevie Wonder Digital,1946115,Entertainment,2025-01-01,28235,77
+Live Nation,ORD-00293107_Live Nation - Stevie Wonder Digital,1946115,Entertainment,2025-01-01,28235,16
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,28230,229
+Diageo,ORD-00288038_(Diageo) Casamigos_Repurposed_PHD_July24June25,1777213,Alcohol,2024-01-01,28020,1792
+Sold Out,ORD-00290685_Bonnie Raitt AEG_Nov 24,1879809,Entertainment,2024-01-01,27930,26
+Aldi,Aldi_Christmas_25,2175479,Food,2025-01-01,27887,1256
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,27872,12
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,27851,7
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,27624,155
+Live Nation,ORD-00286536_Crowded House July-August 2024,1718403,Entertainment,2024-01-01,27527,33
+Live Nation,ORD-00286536_Crowded House July-August 2024,1718403,Entertainment,2024-01-01,27501,34
+Carte D'Or,ORD-00297006 Direct_Digi_Carte D'Or_Q4 2025,2174656,Food,2025-01-01,27076,22
+Itsu ,ORD-00287826_Direct - Itsu_Yonder_Summer Brief_Sept 2024,1748340,Food,2024-01-01,26964,1514
+Itsu ,ORD-00287826_Direct - Itsu_Yonder_Summer Brief_Sept 2024,1748340,Food,2024-01-01,26688,312
+Long Clawson,ORD-00283654_1912_May_June'24_Email_DigiDisplay_Long Clawson,1661119,Food,2024-01-01,26667,25
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,26430,56
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,26350,14
+Sainsburys,ORD-00293866_Sainsbury's Q2 TTD Campaign 2025,2003631,Food,2025-01-01,26088,2035
+Dr Brown,ORD-00293249_Dr Brown's Made For Mums 2025,2020077,Parenting,2025-01-01,25731,13
+Bart Ingredients,ORD-00284412_Bart_Ingredients_2024_Activity_GF,1796038,Food,2024-01-01,25654,32
+Bart Ingredients,ORD-00284412_Bart_Ingredients_2024_Activity_GF,1796038,Food,2024-01-01,25654,18
+Lidl,ORD-00289956_LidlDeluxeChristmas2024_OMD_Oct-Dec,1837113,Food,2024-01-01,25635,22
+Bart Ingredients,ORD-00284412_Bart_Ingredients_2024_Activity_GF,1796038,Food,2024-01-01,25625,9
+Bart Ingredients,ORD-00284412_Bart_Ingredients_2024_Activity_GF,1796038,Food,2024-01-01,25585,119
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,25585,37
+Bart Ingredients,ORD-00284412_Bart_Ingredients_2024_Activity_GF,1796038,Food,2024-01-01,25513,17
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,25488,13
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,25488,17
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,25420,12
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,25183,19
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,25068,73
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,25047,31
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,25014,23
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,25003,66
+Pearson Education Limited,ORD-00275699_Pearson_Q1/Q2_History,1577435,History,2024-01-01,25002,187
+Dr Brown,ORD-00293249_Dr Brown's Made For Mums 2025,2020077,Parenting,2025-01-01,25001,38
+Brown Forman + El Jimador ,ORD-00289639 Brown Forman+El Jimador_Good Food_Christmas 2024,1812591,Alcohol,2024-01-01,25001,16
+Brown Forman + El Jimador ,ORD-00289639 Brown Forman+El Jimador_Good Food_Christmas 2024,1812591,Alcohol,2024-01-01,25001,42
+bet365,ORD-00291479_bet365 H1 2025,1900569,Gambling,2025-01-01,25000,6
+Brown Forman + El Jimador ,ORD-00289639 Brown Forman+El Jimador_Good Food_Christmas 2024,1812591,Alcohol,2024-01-01,25000,25
+Pearson Education Limited,ORD-00275699_Pearson_Q1/Q2_History,1577435,History,2024-01-01,25000,91
+Nacon,ORD-00287184 TestDriveUnlimited_IM_Gaming/TG/RT_Sept24,1830729,Gaming,2024-01-01,24999,24
+Bolsover Cruises,ORD-00291611 Bolsover Cruises,1889378,Travel,2025-01-01,24996,55
+Florette,ORD-00292672_Florette_Caratleeds_Partnership_May-July2025,1993798,Food,2025-01-01,24989,14
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,24229,5
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,24218,6
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,24142,12
+Profile Books ,ORD-00293344 Profile books_April_History Extra,1976920,Entertainment,2025-01-01,23949,31
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,23676,155
+Pearson Education Limited,ORD-00275699_Pearson_Q1/Q2_History,1577435,History,2024-01-01,23612,254
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1962013,Motoring,2025-01-01,23509,20
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,23502,166
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,23487,12
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,23398,30
+Long Clawson,ORD-00283654_1912_May_June'24_Email_DigiDisplay_Long Clawson,1661119,Food,2024-01-01,23338,7
+Long Clawson,ORD-00283654_1912_May_June'24_Email_DigiDisplay_Long Clawson,1661119,Food,2024-01-01,23335,6
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,23231,16
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,23231,9
+Hu Chocolate,ORD-00296935_Hu Chocolate_Q4 2025_GF_RpRecipe_Digi,2222875,Food,2025-01-01,23217,86
+Ecofurb,ORD-00286625_Direct_ParityProjectsEcofurb_Direct_Direct Display & Competition_3rd Sept to 14th Oct,1809137,Entertainment,2024-01-01,23129,51
+Ecofurb,ORD-00286625_Direct_ParityProjectsEcofurb_Direct_Direct Display & Competition_3rd Sept to 14th Oct,1809137,Entertainment,2024-01-01,23124,18
+Ecofurb,ORD-00286625_Direct_ParityProjectsEcofurb_Direct_Direct Display & Competition_3rd Sept to 14th Oct,1809137,Entertainment,2024-01-01,23120,23
+Ecofurb,ORD-00286625_Direct_ParityProjectsEcofurb_Direct_Direct Display & Competition_3rd Sept to 14th Oct,1809137,Entertainment,2024-01-01,23104,20
+Ecofurb,ORD-00286625_Direct_ParityProjectsEcofurb_Direct_Direct Display & Competition_3rd Sept to 14th Oct,1809137,Entertainment,2024-01-01,23102,30
+Ecofurb,ORD-00286625_Direct_ParityProjectsEcofurb_Direct_Direct Display & Competition_3rd Sept to 14th Oct,1809137,Entertainment,2024-01-01,23102,37
+Ecofurb,ORD-00286625_Direct_ParityProjectsEcofurb_Direct_Direct Display & Competition_3rd Sept to 14th Oct,1809137,Entertainment,2024-01-01,23101,40
+Ecofurb,ORD-00286625_Direct_ParityProjectsEcofurb_Direct_Direct Display & Competition_3rd Sept to 14th Oct,1809137,Entertainment,2024-01-01,23101,41
+Ecofurb,ORD-00286625_Direct_ParityProjectsEcofurb_Direct_Direct Display & Competition_3rd Sept to 14th Oct,1809137,Entertainment,2024-01-01,23101,59
+Pernod Ricard,ORD-00282322_Direct_MGOMD_Pernod_AbsolutHunni_MayJune_LD,1613518,Alcohol,2024-01-01,23093,62
+Ecofurb,ORD-00286625_Direct_ParityProjectsEcofurb_Direct_Direct Display & Competition_3rd Sept to 14th Oct,1809137,Entertainment,2024-01-01,23092,18
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,22900,8
+Diageo,ORD-00290180_Diageo_Christmas Cocktail Widget_PHD_Oct-Dec24,1888448,Alcohol,2024-01-01,22534,18
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,22475,12
+AEG,ORD-00291048_Russell Watson (AEG) Q4 2025 Digital,1886559,Entertainment,2024-01-01,22417,0
+AEG,ORD-00291048_Russell Watson (AEG) Q4 2025 Digital,1886559,Entertainment,2024-01-01,22416,0
+AEG,ORD-00291048_Russell Watson (AEG) Q4 2025 Digital,1886559,Entertainment,2024-01-01,22409,0
+AEG,ORD-00291048_Russell Watson (AEG) Q4 2025 Digital,1886559,Entertainment,2024-01-01,22409,17
+The Walt Disney Company,PG_Disney_Zenith_Snow White_March 2025,1932203,Entertainment,2025-01-01,22228,240
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,22196,45
+Jaguar Landrover,ORD-00293258_Direct - JLR_Hearts & Science_Octa_Q1,1982913,Motoring,2025-01-01,22023,20
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,21985,181
+Hyundai Motor (UK),ORD-00291653_Hyundai_Regional_Innocean_Q1_25,1895619,Motoring,2025-01-01,21979,84
+Beko,ORD-00293616_Beko_RunningTotal_GFKitchenvalue2025,1973988,Tech,2025-01-01,21415,83
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,21248,79
+Lidl,ORD-00289956_LidlDeluxeChristmas2024_OMD_Oct-Dec,1837113,Food,2024-01-01,21203,19
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,20858,185
+Agency Press Ltd T/A Sold Out Advertising,ORD-00288550_Ball & Boe September,1763507,Entertainment,2024-01-01,20838,10
+Peter Nyssen,"ORD-00290406_Peter Nyssen Competition, Solus, Social Carousel, Skins 01.08.2025 - 31.10.2025",2113782,Gardening,2025-01-01,20820,152
+Pernod Ricard,ORD-00282322_Direct_MGOMD_Pernod_AbsolutHunni_Espresso Martini,1642196,Alcohol,2024-01-01,20433,52
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,20364,60
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,20359,20
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,20337,7
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,20234,11
+Aldi,ORD-00298137_ Direct- Aldi - Starcom - Jan GF - 12/01 - 31/01 2026,2232285,Supermarket,2026-01-01,20051,32
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,20041,7
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,20022,2
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2026-01-01,20020,12
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2026-01-01,20018,3
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,20014,3
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,20010,4
+The Professional Framing Company,ORD-00290698_Pro Frame Digi 2024,1847232,Entertainment,2024-01-01,20009,41
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2026-01-01,20008,5
+The Professional Framing Company,ORD-00290698_Pro Frame Digi 2024,1847232,Entertainment,2024-01-01,20006,19
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,20004,10
+Sold Out,ORD-00290871_Gary Barlow_Nov,1880326,Entertainment,2024-01-01,20004,7
+Hays Travel,ORD-00297196 Hays Travel_ ARM_ Digital_ Nov_ princess,2177425,Travel,2025-01-01,20002,18
+Sold Out,ORD-00290871_Gary Barlow_Nov,1880326,Entertainment,2024-01-01,20002,24
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2026-01-01,20001,3
+The Professional Framing Company,ORD-00290698_Pro Frame Digi 2024,1847232,Entertainment,2024-01-01,20001,61
+The Professional Framing Company,ORD-00290698_Pro Frame Digi 2024,1847232,Entertainment,2024-01-01,20001,27
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,20000,15
+The Professional Framing Company,ORD-00290698_Pro Frame Digi 2024,1847232,Entertainment,2024-01-01,20000,16
+Sold Out,ORD-00290871_Gary Barlow_Nov,1880326,Entertainment,2024-01-01,19992,12
+Sold Out,ORD-00290871_Gary Barlow_Nov,1880326,Entertainment,2024-01-01,19932,12
+Bloomsbury - Emperor Of Seas,ORD-00288300 Bloomsbury_Total_Sept_History_HE,1801902,Entertainment,2024-01-01,19910,63
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,19879,12
+Grana Padano,ORD-00284396_GRANA_PADANO_GF_COMPETITION_SUMMER24,1680625,Food,2024-01-01,19646,193
+Windsor Castle,ORD-00293267_Windsor Castle - June to August 2025,2094137,History,2025-01-01,19466,210
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,19128,92
+Sainsburys,ORD-00294588_Sainsbury's x Good Food TTD P2 June-August,2045562,Supermarket,2025-01-01,19119,181
+Agency Press Ltd T/A Sold Out Advertising,ORD-00288550_Ball & Boe September,1763507,Entertainment,2024-01-01,18847,30
+Agency Press Ltd T/A Sold Out Advertising,ORD-00288550_Ball & Boe September,1763507,Entertainment,2024-01-01,18824,61
+Agency Press Ltd T/A Sold Out Advertising,ORD-00288550_Ball & Boe September,1763507,Entertainment,2024-01-01,18824,73
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1669752,Alcohol,2024-01-01,18751,10
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1667821,Alcohol,2024-01-01,18751,10
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1669752,Alcohol,2024-01-01,18750,8
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1667821,Alcohol,2024-01-01,18750,44
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1667821,Alcohol,2024-01-01,18750,8
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1669752,Alcohol,2024-01-01,18750,44
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1667821,Alcohol,2024-01-01,18748,4
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1669752,Alcohol,2024-01-01,18748,4
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1669752,Alcohol,2024-01-01,18742,20
+Penfolds,ORD-00282892_Penfolds_2024_Activity,1667821,Alcohol,2024-01-01,18742,20
+Hays Travel - June ,ORD-00293796 hays Travel_ ARM_ Digital_ May,2020315,Travel,2025-01-01,18196,19
+Sold Out,ORD-00290685_Bonnie Raitt AEG_Nov 24,1879809,Entertainment,2024-01-01,17927,14
+shell,ORD-00286771_Shell x Top Gear VPower,1733425,Motoring,2024-01-01,17714,2
+Hyundai Motor (UK),ORD-00291653_Hyundai_Regional_Innocean_Q1_25,1895619,Motoring,2025-01-01,17231,24
+Aldi,ORD-00293735 & ORD-00293701_Aldi_May_2025,1995563,Food,2025-01-01,17225,1462
+Pernod Ricard,ORD-00297666_PernodRicard_Absolut&Kahlua_December2025,2195115,Alcohol,2025-01-01,17092,7
+Pernod Ricard,ORD-00297666 & ORD-00297808 _PernodRicard_Absolut&Kahlua_December2025,2206209,Alcohol,2025-01-01,17088,7
+Arla Lurpak,PG_Arla_Castello_Q4_24/ORD-00290429 (Native),1887285,Food,2024-01-01,17011,188
+Arla Lurpak,PG_Arla_Castello_Q4_24/ORD-00290429 (Native),1887285,Food,2024-01-01,16954,128
+Diageo,Johnnie Walker Partnership_Diageo_PHD_AprilJune25,1974104,Alcohol,2025-01-01,16867,207
+Agency Press Ltd T/A Sold Out Advertising,ORD-00288550_Ball & Boe September,1763507,Entertainment,2024-01-01,16848,12
+Apple,ORD-00299603 _Direct_Apple_Marcom_ RT_March26,2288746,Entertainment,2026-01-01,16550,685
+River Street Events,River Street Events Ltd _GW_Events_-_Digi_promo,1621866,Gardening,2024-01-01,16511,12
+Apple,ORD-00299603 _Direct_Apple_Marcom_ RT_March26,2288746,Entertainment,2026-01-01,16480,454
+Gousto,ORD-00297780_Gousto_brandpartnership_26,2224957,Food,2026-01-01,16161,231
+Apple,ORD-00299603 _Direct_Apple_Marcom_ RT_March26,2288746,Entertainment,2026-01-01,15788,528
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,15721,16
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,15719,8
+Nintendo,ORD-00288651 Nintendo: Echoes of Wisdom,1814079,Gaming,2024-01-01,15675,184
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,15222,125
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,15105,5
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,15099,3
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,15099,11
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,15033,14
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,15018,2
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,15016,2
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,15011,128
+Bolsover Cruises,ORD-00291611 Bolsover Cruises,1889378,Travel,2025-01-01,15011,9
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,15008,2
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,15007,8
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,15007,11
+Aldi,ORD-00293735 & ORD-00293701_Aldi_May_2025,1995563,Supermarket,2025-01-01,15001,539
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,15000,2
+Thames and Hudson // D-Day Atlas - Charles Messenger,ORD-00283523 D-Day Atlas_Thames&Hudson_Total_May/June_H,1647175,Entertainment,2024-01-01,15000,23
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,15000,9
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,14751,35
+Live Nation,ORD-00284373 _Clannad Live Nation_May,1661251,Entertainment,2024-01-01,14671,7
+Beko,ORD-00293616_Beko_RunningTotal_GFKitchenvalue2025,1973988,Tech,2025-01-01,14287,340
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,13919,157
+Sainsburys,ORD-00294588_Sainsbury's x Good Food TTD P2 June-August,2045562,Supermarket,2025-01-01,13670,155
+Angelcare,ORD-00287020_Angelcare Made For Mums 2024,1791084,Parenting,2024-01-01,12861,10
+Peugeot,ORD-00294321_Direct_Peugeot e3008_Q2_2025,2030170,Motoring,2025-01-01,12839,113
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,12749,60
+Oxford University Press,ORD-00281393_OUP_march_HE,1663035,History,2024-01-01,12501,13
+Oxford University Press,ORD-00281393_OUP_march_HE,1663035,History,2024-01-01,12500,20
+La Vieja Fábrica,ORD-00293061_La Vieja Fábrica_Digi&Print_Oli&GF_SeptOct,2105575,Food,2025-01-01,12416,21
+Sold Out,ORD-00290871_Gary Barlow_Nov,1880326,Entertainment,2024-01-01,12336,11
+Paramount+,Paramount+_Wavemaker_High Stakes Drama_APP,1808893,Entertainment,2024-01-01,12325,323
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,11838,100
+Pernod Ricard,ORD-00297666_PernodRicard_Absolut&Kahlua_December2025,2195115,Alcohol,2025-01-01,11710,1
+Pernod Ricard,ORD-00297666 & ORD-00297808 _PernodRicard_Absolut&Kahlua_December2025,2206209,Alcohol,2025-01-01,11688,1
+Pernod Ricard,ORD-00289957_Direct_MGOMD_Pernod_Kahlua_Truenative_Dec_LD,1856943,Alcohol,2024-01-01,11628,199
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,11615,7
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,11595,30
+Immediate Media,Amazon XCM - Eclipse Takeover. 20/11/25,2187664,Retail,2025-01-01,11593,6
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,11304,194
+Live Nation,ORD-00284373 _Clannad Live Nation_May,1661251,Entertainment,2024-01-01,11265,3
+Sainsburys,ORD-00294588_Sainsbury's x Good Food TTD P2 June-August,2045562,Food,2025-01-01,11205,1020
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,11016,213
+Sainsburys,ORD-00294588_Sainsbury's x Good Food TTD P2 June-August,2045562,Food,2025-01-01,10721,465
+Abbott,ORD-00295651 Abbott Freestyle Libre ,2193187,Food,2025-01-01,10353,885
+BSskyb,ORD-00295733_Sky X Netflix_Zenith_Partnership_September,2125057,Entertainment,2025-01-01,10109,0
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,10071,113
+Sainsburys,ORD-00294588_Sainsbury's x Good Food TTD P2 June-August,2045562,Food,2025-01-01,10036,508
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,10001,2
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,10000,8
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,1835419,Tech,2024-01-01,9999,0
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,9982,5
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,9951,3
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,9950,1
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,9949,4
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,9934,4
+Bloomsbury - Emperor Of Seas,ORD-00288300 Bloomsbury_Total_Sept_History_HE,1801902,Entertainment,2024-01-01,9900,35
+President Cream,ORD-00298432_President Cream x Good Food,2254186,Food,2026-01-01,9700,37
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2026-01-01,9564,205
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,9414,21
+Hays Travel - June ,ORD-00293796 hays Travel_ ARM_ Digital_ May,2020315,Travel,2025-01-01,9118,2
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,9105,59
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,8563,6
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,8199,48
+Alpen,ORD-00277683_Alpen_GetMeMedia_Nov-Sept,1601248,Food,2024-01-01,7827,934
+Sold Out,ORD-00290685_Bonnie Raitt AEG_Nov 24,1879809,Entertainment,2024-01-01,7774,9
+Pernod Ricard,ORD-00290259_Direct_MGOMD_Pernod_Altos_-Dec__LD,1856900,Alcohol,2024-01-01,7634,63
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,7552,1
+Live Nation,ORD-00284373 _Clannad Live Nation_May,1661251,Entertainment,2024-01-01,7517,4
+Live Nation,ORD-00284373 _Clannad Live Nation_May,1661251,Entertainment,2024-01-01,7507,6
+Live Nation,ORD-00284373 _Clannad Live Nation_May,1661251,Entertainment,2024-01-01,7502,8
+Live Nation,ORD-00284373 _Clannad Live Nation_May,1661251,Entertainment,2024-01-01,7500,6
+Peugeot,ORD-00294321_Direct_Peugeot e3008_Q2_2025,2030170,Motoring,2025-01-01,7458,48
+Brown Forman + El Jimador ,ORD-00289639 Brown Forman+El Jimador_Good Food_Christmas 2024,1812591,Alcohol,2024-01-01,7250,19
+Transport for Wales Rail,ORD-00289657_Transport For Wales: Kids Go Free,1815657,Travel,2024-01-01,7177,10
+Piccolo,ORD-00293123 Piccolo_June_2025_GF_DIGI,2030423,Food,2025-01-01,7170,46
+Pink Lady,ORD-00284147_Pink Lady_McCann Central_Native GF,1664559,Food,2024-01-01,7086,26
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,6707,16
+Skoda,ORD-00271360 _Direct_ SkodaFleet_PHD_H2_2023_LD,1466969,Motoring,2024-01-01,6661,9
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,6477,15
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,6358,79
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,6356,13
+Diageo,Johnnie Walker Partnership_Diageo_PHD_AprilJune25,1974104,Alcohol,2025-01-01,5966,129
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,5936,10
+Diageo,Johnnie Walker Partnership_Diageo_PHD_AprilJune25,1974104,Alcohol,2025-01-01,5848,213
+Sainsburys,ORD-00293866_Sainsbury's Q2 TTD Campaign 2025,2003631,Food,2025-01-01,5758,310
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,5627,88
+Live Nation,ORD-00293107_Live Nation - Stevie Wonder Digital,1946115,Entertainment,2025-01-01,5514,12
+Pernod Ricard,ORD-00282322_Direct_MGOMD_Pernod_AbsolutHunni_MayJune_LD,1613518,Alcohol,2024-01-01,5507,26
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,5426,50
+Merchant Gourmet,ORD-00291231_Merchant Gourmet_Yonder_Good Food_January 2025,1895723,Food,2025-01-01,5332,14
+Disney+,PG_Digital_Disney_Zenith_InsideOut2MayJun-2024,1639286,Entertainment,2024-01-01,5295,16
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,5264,6
+The Royal Mint,ORD-00290615_Royal_Mint_Xmas_2024_GF_OLI_DIGI,1837608,Food,2024-01-01,5174,9
+The Royal Mint,ORD-00290615_RM_Xmas_2024_GF_OLI_DIGI ,1827231,Food,2024-01-01,5174,9
+B&M,"ORD-00293391 B&M_ Dentsu_ MFM, GF_ Digi_ April",1972520,Food,2025-01-01,5005,0
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,5003,17
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,4985,9
+Diageo,Johnnie Walker Partnership_Diageo_PHD_AprilJune25,1974104,Alcohol,2025-01-01,4941,127
+Ocado,ORD-00285279_Ocado Made For Mums 2024,1798599,Parenting,2024-01-01,4828,63
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,4824,0
+Aldi,ORD-00293735 & ORD-00293701_Aldi_May_2025,1995563,Supermarket,2025-01-01,4784,0
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,4728,0
+The Walt Disney Company,PG_NatGeo_Zenith_Top_Gun_19th_September,2125006,Entertainment,2025-01-01,4677,42
+Pearson Education Limited,ORD-00275699_Pearson_Q1/Q2_History,1577435,History,2024-01-01,4655,23
+Disney+,PG_Digital_Disney_Zenith_InsideOut2MayJun-2024,1639286,Entertainment,2024-01-01,4640,12
+Florette,ORD-00292672_Florette_Caratleeds_Partnership_May-July2025,1993798,Food,2025-01-01,4610,102
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,4574,13
+Sainsburys,ORD-00293866_Sainsbury's Q2 TTD Campaign 2025,2003631,Food,2025-01-01,4463,433
+Bletchley Park,ORD-00281879_Bletchley Park_Grove media_April_History,1657730,History,2024-01-01,4457,191
+My Expert Midwife,ORD-00294341_Direct_MyexpertMidwife_Alchemy_Digi MFM,2062059,Parenting,2025-01-01,4354,8
+Disney+,PG_Digital_Disney_Zenith_InsideOut2MayJun-2024,1639286,Entertainment,2024-01-01,4266,33
+Disney+,PG_Disney_Inside Out 2 EHV_Aug 24,1731379,Entertainment,2024-01-01,4166,46
+Paramount+,Paramount+_Wavemaker_High Stakes Drama_APP,1808893,Entertainment,2024-01-01,4087,0
+Live Nation,ORD-00284373 _Clannad Live Nation_May,1661251,Entertainment,2024-01-01,4068,5
+shell,ORD-00286771_Shell x Top Gear VPower,1733425,Motoring,2024-01-01,4000,6
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3965,3
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3963,2
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3963,2
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,3947,44
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3900,4
+shell,ORD-00294734_Shell F1 x Top Gear 2025,2071034,On-Demand,2025-01-01,3765,55
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3689,2
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3689,1
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3689,4
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,3658,3
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3602,10
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3560,14
+Waitrose,ORD-00293374_Direct_Waitrose_MGOMD_Easter25_LD,1969303,Food,2025-01-01,3544,445
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,3509,3
+The Royal Mint,ORD-00298555_TRM_ ROM_ Digital_ Jan_ Concorde,2256655,Entertainment,2026-01-01,3371,9
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,3312,61
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3255,10
+Transport for Wales Rail,ORD-00289657_Transport For Wales: Kids Go Free,1815657,Travel,2024-01-01,3244,7
+TUI,ORD-00286345 _TUI_Marella Cruise digi campaign - Aug/Sep 2024,1716978,Travel,2024-01-01,3155,13
+Audible,Audible_wavemaker_Comedy_July25,2054149,Entertainment,2025-01-01,3146,12
+Ecofurb,ORD-00286625_Direct_ParityProjectsEcofurb_Direct_Direct Display & Competition_3rd Sept to 14th Oct,1809137,Entertainment,2024-01-01,3100,11
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3060,1
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3060,0
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,3060,1
+Sainsburys,ORD-00293866_Sainsbury's Q2 TTD Campaign 2025,2003631,Food,2025-01-01,3013,140
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,2907,1
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,2891,78
+Arla Lurpak,PG_Arla_Castello_Q4_24/ORD-00290429 (Native),1887285,Food,2024-01-01,2661,38
+Arla Lurpak,PG_Arla_Castello_Q4_24/ORD-00290429 (Native),1887285,Food,2024-01-01,2653,74
+Pearson Examiner,ORD-00289977 Pearson_History_Q1 2025,1991085,Parenting,2025-01-01,2588,25
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,2464,9
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,2396,5
+Barretine Spring + Summer GW,ORD-00278706_Barretine Spring + Summer GW,1661668,Gardening,2024-01-01,2277,11
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2025-01-01,2276,0
+Positec Worx,ORD-00288027/ORD-00288030_Positec Q4 Burst - Worx,1876392,Gardening,2024-01-01,2265,2
+Positec Worx,ORD-00288027_Positec Q4 Burst - Worx,1804403,Gardening,2024-01-01,2265,2
+Nacon - Rugby '25,ORD-00291547 Nacon_Rugby25_IM_RT_feb25,1945104,Gaming,2025-01-01,2261,48
+Not On The High Street,Not On The High Street Xmas 24,1814035,Entertainment,2024-01-01,2258,39
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,2140,10
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,2127,6
+Sainsburys,ORD-00293866_Sainsbury's Q2 TTD Campaign 2025,2003631,Food,2025-01-01,1931,220
+Diageo,Diageo_JohnnieWalkerBlack_Sep-Dec (Native),1817891,Alcohol,2024-01-01,1926,7
+Disney+,PG_Digital_Disney_Zenith_InsideOut2MayJun-2024,1639286,Entertainment,2024-01-01,1919,18
+Centrum,ORD-00291473_Centrum_Spark_Vitamins 2025,1896853,Health,2025-01-01,1897,17
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,1759,2
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,1745,4
+Diageo,ORD-00281883 & ORD-00281885 & ORD-00282491 & ORD-00282487_ Diageo_H2 Partnership_PHD_Mar-June24 (Gins),1601153,Alcohol,2024-01-01,1725,4
+Bloomsbury,ORD-00296570 Bloomsbury Display & Solus,2193064,Entertainment,2025-01-01,1680,2
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,1679,20
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,1622,4
+BBC Good Food,GF App House Ads ,2234260,Food,2025-01-01,1570,11
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,1570,11
+Grana Padano,ORD-00290516_Grana_Padano_Xmas_GF_24,1878439,Food,2024-01-01,1396,9
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,1338,8
+Sainsburys,ORD-00293866_Sainsbury's Q2 TTD Campaign 2025,2003631,Food,2025-01-01,1337,126
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,1251,0
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,1250,4
+Hays Travel,Hays Travel_ All response_ Digital_ 2024,1726052,Travel,2024-01-01,1248,0
+David Austin Roses,ORD-00281749 /David Austin Roses/Gardeners World May-June24,1648517,Gardening,2024-01-01,1239,7
+Ford,ORD-00294423 & ORD-00294461_Direct_ Digi_Ford Power Promise Part 1,2030355,Motoring,2025-01-01,1135,3
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2026-01-01,1134,0
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2026-01-01,1103,1
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2026-01-01,1075,0
+Finish,ORD-00295079_Finish_Zenith_2025/26 partnership - July-June,2202971,Food,2026-01-01,1034,0
+Electorial Commission,ORD-00296311 & ORD-00296312_EC Voter ID & EC Voter Reg_UMBirm_GF_MMA_Feb May2026,2256951,Government,2026-01-01,905,8
+BBC Good Food,GF App House Ads ,2234260,Food,2025-01-01,536,13
+BBC Good Food,Magazine-Subscription-GF-Christmas-Issue,2230055,Food,2025-01-01,536,13
+Merchant Gourmet,ORD-00291231_Merchant Gourmet_Yonder_Good Food_January 2025,1895723,Food,2025-01-01,532,16
+Disney+,PG_Digital_Disney_Zenith_InsideOut2MayJun-2024,1639286,Entertainment,2024-01-01,523,2
+Diageo,ORD-Multi_Diageo_H1 24 Gins Partnership_PHD_July-Dec24,1807305,Alcohol,2024-01-01,505,0
+Mars,ORD-00292262_MarsSprinbake2025_M&MS_Jan-April,1924981,Food,2025-01-01,388,0
+Birds Eye,ORD-00298551_Birds Eye Peas - Zenith - March - April,2277873,Food,2026-01-01,383,45
+Live Nation,ORD-00284373 _Clannad Live Nation_May,1661251,Entertainment,2024-01-01,326,0
+Ocado,ORD-00285279_Ocado Made For Mums 2024,1798599,Parenting,2024-01-01,278,0
+Disney+,PG_Digital_Disney_Zenith_InsideOut2MayJun-2024,1639286,Entertainment,2024-01-01,278,0
+Laithwaites,Marketing-house-external-partnership,2157559,Alcohol,2025-01-01,278,0
+Lego UK,ORD-00285443_LEGO_INITIATIVE_DRIVE_JUNE/JULY,1722584,Parenting,2024-01-01,203,1
+Playseat,ORD-00285484 Playseat_IM_TopGear_August,1731409,Gaming,2024-01-01,182,10
+Disney+,PG_Digital_Disney_Zenith_InsideOut2MayJun-2024,1639286,Entertainment,2024-01-01,170,0
+Nacon,ORD-00294535 Nacon_Architect Life_IM_July_RT,2064490,Gaming,2025-01-01,99,4
+Outfit 7,ORD-00285090 Outfit7,1687862,Gaming,2024-01-01,78,1
+Nintendo,ORD-00288651 Nintendo: Echoes of Wisdom,1814079,Gaming,2024-01-01,71,1
+Box,Box.co.uk/Norton_Digital Skin_December,2237872,Parenting,2025-01-01,32,0
+Peugeot,ORD-00294321_Direct_Peugeot e3008_Q2_2025,2030170,Motoring,2025-01-01,17,0
+Aldi,ORD-00293735 & ORD-00293701_Aldi_May_2025,1995563,Supermarket,2025-01-01,10,3

--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -40,6 +40,7 @@ interface InsightsResult {
   audience_timing: string;
   google_trends: string;
   format_recommendations: string;
+  campaign_history: string;
   client_brief_summary: string;
 }
 
@@ -544,6 +545,15 @@ export default function InsightsTool() {
                       </div>
                     ))}
                   </div>
+                </CollapsiblePanel>
+              )}
+
+              {/* Campaign History panel */}
+              {result.campaign_history && result.campaign_history !== "No previous campaign data found for this advertiser." && (
+                <CollapsiblePanel title="Campaign History" defaultOpen={false}>
+                  <p className="text-on-surface-variant text-sm leading-relaxed whitespace-pre-wrap">
+                    {result.campaign_history}
+                  </p>
                 </CollapsiblePanel>
               )}
 

--- a/src/campaign_history.py
+++ b/src/campaign_history.py
@@ -1,0 +1,103 @@
+import csv
+import os
+
+DEFAULT_CSV_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "campaign_history.csv")
+
+NO_DATA_MESSAGE = "No previous campaign data found for this advertiser."
+
+
+def get_campaign_summary(advertiser, csv_path=None):
+    # type: (str, str) -> dict
+    """Look up an advertiser's campaign history and return a summary.
+
+    Returns a dict with:
+        summary (str): prompt-ready formatted summary
+        campaigns (list): raw campaign records (one per campaign ID)
+    """
+    if csv_path is None:
+        csv_path = DEFAULT_CSV_PATH
+
+    if not os.path.exists(csv_path):
+        return {"summary": NO_DATA_MESSAGE, "campaigns": []}
+
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    if not rows:
+        return {"summary": NO_DATA_MESSAGE, "campaigns": []}
+
+    # Filter rows matching advertiser (case-insensitive substring)
+    search = advertiser.lower()
+    matched = [r for r in rows if search in r.get("advertiser", "").lower()]
+
+    if not matched:
+        return {"summary": NO_DATA_MESSAGE, "campaigns": []}
+
+    # Aggregate by campaign_id to avoid counting individual placements
+    campaigns = {}
+    for row in matched:
+        cid = row.get("campaign_id", "")
+        impressions = int(row.get("impressions", 0) or 0)
+        clicks = int(row.get("clicks", 0) or 0)
+
+        if cid in campaigns:
+            campaigns[cid]["impressions"] += impressions
+            campaigns[cid]["clicks"] += clicks
+        else:
+            campaigns[cid] = {
+                "campaign_id": cid,
+                "campaign_name": row.get("campaign_name", "Unknown"),
+                "category": row.get("category", "Unknown"),
+                "start_date": row.get("start_date", "Unknown"),
+                "impressions": impressions,
+                "clicks": clicks,
+            }
+
+    campaign_list = list(campaigns.values())
+
+    # Compute aggregates
+    total_impressions = sum(c["impressions"] for c in campaign_list)
+    total_clicks = sum(c["clicks"] for c in campaign_list)
+    avg_ctr = (total_clicks / total_impressions * 100) if total_impressions > 0 else 0.0
+
+    categories = sorted(set(c["category"] for c in campaign_list if c["category"] != "Unknown"))
+
+    # Most recent campaign
+    most_recent = max(campaign_list, key=lambda c: c["start_date"])
+
+    # Best campaign by CTR (impressions as tiebreaker)
+    def _ctr_sort_key(c):
+        ctr = (c["clicks"] / c["impressions"] * 100) if c["impressions"] > 0 else 0.0
+        return (ctr, c["impressions"])
+
+    best = max(campaign_list, key=_ctr_sort_key)
+    best_ctr = (best["clicks"] / best["impressions"] * 100) if best["impressions"] > 0 else 0.0
+
+    # Format summary
+    summary_lines = [
+        "Campaign history for '%s':" % advertiser,
+        "- Total campaigns: %d" % len(campaign_list),
+        "- Categories: %s" % (", ".join(categories) if categories else "N/A"),
+        "- Total impressions: %s" % _format_number(total_impressions),
+        "- Average CTR: %.2f%%" % avg_ctr,
+        "- Most recent campaign: %s (%s)" % (most_recent["campaign_name"], most_recent["start_date"]),
+        "- Best performing: %s (%.2f%% CTR, %s impressions)" % (
+            best["campaign_name"], best_ctr, _format_number(best["impressions"])
+        ),
+    ]
+
+    return {
+        "summary": "\n".join(summary_lines),
+        "campaigns": campaign_list,
+    }
+
+
+def _format_number(n):
+    # type: (int) -> str
+    """Format a large number with commas for readability."""
+    if n >= 1000000:
+        return "%.1fM" % (n / 1000000.0)
+    if n >= 1000:
+        return "%.1fK" % (n / 1000.0)
+    return str(n)

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -27,6 +27,9 @@ A detailed factual summary of who the advertiser is, grounded in the research pr
 - Any relevant parent company or group context
 Draw from ALL the advertiser research sections (company overview, strategy, recent news). Do not speculate beyond what the research supports. Include source links where the research provides them.
 
+## Previous Campaign History
+If the advertiser has previous campaign history with us, summarise the relationship: how many campaigns, which categories, overall performance, and what worked best. Reference specific past campaigns when making recommendations — e.g. suggest building on formats or categories that performed well previously. Note how recently they last worked with us to frame the relationship (active partner vs. returning client). If no campaign history is available, note this and proceed based on other data sources.
+
 ## Editorial Insights
 Key themes and opportunities identified from editor interviews. Reference specific editors and publications.
 
@@ -104,6 +107,13 @@ The following research was gathered from multiple angles on the advertiser. Use 
 The following is the full catalogue of available ad formats with performance benchmarks. Use this to build the Recommended Products section.
 
 {format_recommendations}
+
+---
+
+### Campaign History
+The following is the advertiser's previous campaign history with us. Use this to build the Previous Campaign History section and to inform recommendations.
+
+{campaign_history}
 
 ---
 

--- a/src/synthesiser.py
+++ b/src/synthesiser.py
@@ -6,6 +6,7 @@ from src.audience import load_audience_data, get_topic_trends
 from src.trends import get_trend_data
 from src.brief import summarise_brief
 from src.formats import load_format_data
+from src.campaign_history import get_campaign_summary
 from src.prompts import SYSTEM_PROMPT, USER_PROMPT_TEMPLATE
 
 
@@ -77,10 +78,14 @@ def generate_insights(
     # 5. Load format recommendations
     format_recommendations = load_format_data()
 
-    # 6. Summarise client brief if provided
+    # 6. Look up previous campaign history
+    campaign_result = get_campaign_summary(advertiser)
+    campaign_history = campaign_result["summary"]
+
+    # 7. Summarise client brief if provided
     client_brief_summary = summarise_brief(client_brief)
 
-    # 7. Assemble prompt
+    # 8. Assemble prompt
     user_prompt = USER_PROMPT_TEMPLATE.format(
         topic=topic,
         advertiser=advertiser,
@@ -90,10 +95,11 @@ def generate_insights(
         audience_timing=audience_timing,
         google_trends=google_trends,
         format_recommendations=format_recommendations,
+        campaign_history=campaign_history,
         client_brief=client_brief_summary,
     )
 
-    # 8. Call GPT-4o
+    # 9. Call GPT-4o
     client = OpenAI(api_key=config.OPENAI_API_KEY)
     response = client.chat.completions.create(
         model=config.CHAT_MODEL,
@@ -114,5 +120,6 @@ def generate_insights(
         "audience_timing": audience_timing,
         "google_trends": google_trends,
         "format_recommendations": format_recommendations,
+        "campaign_history": campaign_history,
         "client_brief_summary": client_brief_summary,
     }

--- a/tests/test_campaign_history.py
+++ b/tests/test_campaign_history.py
@@ -1,0 +1,195 @@
+import os
+import tempfile
+import csv
+
+from src.campaign_history import get_campaign_summary, NO_DATA_MESSAGE
+
+
+def _create_test_csv(path, rows=None):
+    """Create a campaign history CSV with the expected columns."""
+    if rows is None:
+        rows = [
+            {
+                "advertiser": "Tesco",
+                "campaign_name": "Tesco Easter",
+                "campaign_id": "100",
+                "category": "Supermarket",
+                "start_date": "2024-04-01",
+                "impressions": "5000000",
+                "clicks": "10000",
+            },
+            {
+                "advertiser": "Tesco",
+                "campaign_name": "Tesco Summer",
+                "campaign_id": "101",
+                "category": "Food",
+                "start_date": "2024-07-01",
+                "impressions": "3000000",
+                "clicks": "9000",
+            },
+            {
+                "advertiser": "Jaguar Landrover",
+                "campaign_name": "JLR Launch",
+                "campaign_id": "200",
+                "category": "Motoring",
+                "start_date": "2025-01-01",
+                "impressions": "2000000",
+                "clicks": "8000",
+            },
+            {
+                "advertiser": "Aldi",
+                "campaign_name": "Aldi Christmas",
+                "campaign_id": "300",
+                "category": "Supermarket",
+                "start_date": "2024-12-01",
+                "impressions": "4000000",
+                "clicks": "6000",
+            },
+        ]
+    fieldnames = ["advertiser", "campaign_name", "campaign_id", "category",
+                  "start_date", "impressions", "clicks"]
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_exact_match_returns_summary():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path)
+
+        result = get_campaign_summary("Tesco", csv_path)
+
+        assert "Tesco" in result["summary"]
+        assert "Total campaigns: 2" in result["summary"]
+        assert len(result["campaigns"]) == 2
+
+
+def test_substring_match():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path)
+
+        result = get_campaign_summary("Jaguar", csv_path)
+
+        assert "JLR Launch" in result["summary"]
+        assert len(result["campaigns"]) == 1
+
+
+def test_case_insensitive_match():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path)
+
+        result = get_campaign_summary("tesco", csv_path)
+
+        assert "Total campaigns: 2" in result["summary"]
+        assert len(result["campaigns"]) == 2
+
+
+def test_no_match_returns_fallback():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path)
+
+        result = get_campaign_summary("NonExistentBrand", csv_path)
+
+        assert result["summary"] == NO_DATA_MESSAGE
+        assert result["campaigns"] == []
+
+
+def test_missing_csv_returns_fallback():
+    result = get_campaign_summary("Tesco", "/nonexistent/path/campaigns.csv")
+
+    assert result["summary"] == NO_DATA_MESSAGE
+    assert result["campaigns"] == []
+
+
+def test_empty_csv_returns_fallback():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path, rows=[])
+
+        result = get_campaign_summary("Tesco", csv_path)
+
+        assert result["summary"] == NO_DATA_MESSAGE
+        assert result["campaigns"] == []
+
+
+def test_aggregates_by_campaign_id():
+    """Multiple rows with same campaign_id should be aggregated into one campaign."""
+    rows = [
+        {
+            "advertiser": "Tesco",
+            "campaign_name": "Tesco Easter",
+            "campaign_id": "100",
+            "category": "Supermarket",
+            "start_date": "2024-04-01",
+            "impressions": "3000000",
+            "clicks": "6000",
+        },
+        {
+            "advertiser": "Tesco",
+            "campaign_name": "Tesco Easter",
+            "campaign_id": "100",
+            "category": "Supermarket",
+            "start_date": "2024-04-01",
+            "impressions": "2000000",
+            "clicks": "4000",
+        },
+    ]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path, rows=rows)
+
+        result = get_campaign_summary("Tesco", csv_path)
+
+        assert "Total campaigns: 1" in result["summary"]
+        assert len(result["campaigns"]) == 1
+        assert result["campaigns"][0]["impressions"] == 5000000
+        assert result["campaigns"][0]["clicks"] == 10000
+
+
+def test_ctr_calculation():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path)
+
+        result = get_campaign_summary("Tesco", csv_path)
+
+        # Tesco: 8M impressions, 19K clicks = 0.24% CTR
+        assert "Average CTR: 0.24%" in result["summary"]
+
+
+def test_categories_in_summary():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path)
+
+        result = get_campaign_summary("Tesco", csv_path)
+
+        assert "Food" in result["summary"]
+        assert "Supermarket" in result["summary"]
+
+
+def test_most_recent_campaign():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path)
+
+        result = get_campaign_summary("Tesco", csv_path)
+
+        assert "Tesco Summer" in result["summary"]
+        assert "2024-07-01" in result["summary"]
+
+
+def test_best_performing_campaign():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path)
+
+        result = get_campaign_summary("Tesco", csv_path)
+
+        # Tesco Summer: 9000/3000000 = 0.30% CTR (higher than Easter 0.20%)
+        assert "Best performing: Tesco Summer" in result["summary"]

--- a/tests/test_synthesiser.py
+++ b/tests/test_synthesiser.py
@@ -58,6 +58,15 @@ def test_system_prompt_at_a_glance_has_fixed_labels():
     assert "Top Format" in glance_section
 
 
+def test_system_prompt_has_campaign_history_section():
+    """SYSTEM_PROMPT should contain a Previous Campaign History section after Advertiser Overview."""
+    assert "Previous Campaign History" in SYSTEM_PROMPT
+    history_pos = SYSTEM_PROMPT.index("Previous Campaign History")
+    overview_pos = SYSTEM_PROMPT.index("Advertiser Overview")
+    editorial_pos = SYSTEM_PROMPT.index("Editorial Insights")
+    assert overview_pos < history_pos < editorial_pos
+
+
 def test_system_prompt_has_client_brief_instruction():
     """SYSTEM_PROMPT should instruct GPT-4o to tailor sections to the client brief."""
     assert "client brief" in SYSTEM_PROMPT.lower()
@@ -103,6 +112,7 @@ def test_user_prompt_template_has_placeholders():
     assert "{google_trends}" in USER_PROMPT_TEMPLATE
     assert "{advertiser_kpi}" in USER_PROMPT_TEMPLATE
     assert "{format_recommendations}" in USER_PROMPT_TEMPLATE
+    assert "{campaign_history}" in USER_PROMPT_TEMPLATE
     assert "{client_brief}" in USER_PROMPT_TEMPLATE
 
 
@@ -116,6 +126,7 @@ def test_user_prompt_renders():
         audience_timing="some timing",
         google_trends="some trends",
         format_recommendations="some formats",
+        campaign_history="some history",
         client_brief="some brief",
     )
     assert "test topic" in rendered
@@ -135,6 +146,7 @@ def test_generate_insights_accepts_kpi_and_injects_into_prompt():
          patch("src.synthesiser.research_advertiser", return_value=[]), \
          patch("src.synthesiser.load_audience_data") as mock_load, \
          patch("src.synthesiser.get_topic_trends", return_value="No data"), \
+         patch("src.synthesiser.get_campaign_summary", return_value={"summary": "No previous campaign data found for this advertiser.", "campaigns": []}), \
          patch("src.synthesiser.OpenAI") as mock_openai_cls:
 
         mock_search.return_value = {"documents": [[]], "metadatas": [[]], "distances": [[]]}
@@ -144,11 +156,12 @@ def test_generate_insights_accepts_kpi_and_injects_into_prompt():
         mock_openai_cls.return_value = mock_client
 
         from src.synthesiser import generate_insights
-        generate_insights(topic="test", advertiser="TestCo", kpi="Clicks", include_google_trends=False)
+        result = generate_insights(topic="test", advertiser="TestCo", kpi="Clicks", include_google_trends=False)
 
         call_args = mock_client.chat.completions.create.call_args
         user_prompt = call_args[1]["messages"][1]["content"]
         assert "Clicks" in user_prompt
+        assert "campaign_history" in result
 
 
 def test_format_editorial_insights_empty():


### PR DESCRIPTION
## Summary

- New `src/campaign_history.py` module that loads advertiser campaign history from CSV, matches by case-insensitive substring, aggregates by campaign ID, and returns a formatted summary (campaign count, categories, impressions, CTR, best performer)
- Integrated as a new step in `generate_insights()` pipeline with `{campaign_history}` prompt placeholder and "Previous Campaign History" section in system prompt
- Frontend displays campaign history in a collapsible panel alongside existing data sources

Closes #72, #73, #74
Parent PRD: #71

## Test plan

- [x] 11 unit tests for campaign history module (matching, aggregation, edge cases)
- [x] Updated synthesiser tests (32 total passing)
- [x] Frontend build passes
- [ ] Manual test: generate a brief for an advertiser in the CSV (e.g. "Tesco") and verify campaign history appears in the report and collapsible panel
- [ ] Manual test: generate a brief for an unknown advertiser and verify graceful fallback message

🤖 Generated with [Claude Code](https://claude.com/claude-code)