### PR TITLE
Improve assistant response readability

### DIFF
--- a/frontend/app/assistant/page.tsx
+++ b/frontend/app/assistant/page.tsx
@@ -203,7 +203,7 @@ export default function AssistantPage() {
                 }`}
               >
                 {msg.role === "assistant" ? (
-                  <div className="prose prose-invert prose-sm max-w-none">
+                  <div className="prose prose-invert prose-sm max-w-none prose-p:mb-3 prose-ul:my-3 prose-li:my-1 prose-headings:mt-4 prose-headings:mb-2">
                     <ReactMarkdown>{msg.content || "..."}</ReactMarkdown>
                   </div>
                 ) : (

--- a/src/assistant.py
+++ b/src/assistant.py
@@ -98,6 +98,7 @@ Rules:
 3. Be concise and practical — sales people want quick answers.
 4. When discussing segments, include sizes where available.
 5. You can use the search_segments tool to look up specific segments from the segment library.
+6. Format responses for readability: use blank lines between paragraphs, bullet points for lists, and bold headers (e.g. **Section Name:**) to break up distinct topics. Never write long blocks of unbroken text.
 
 ## Knowledge Base
 


### PR DESCRIPTION
## Summary

- Add formatting rule (rule 6) to assistant system prompt instructing the LLM to use blank lines between paragraphs, bullet points for lists, and bold headers to break up topics
- Add Tailwind prose spacing modifiers to the chat message component for consistent visual gaps between paragraphs, lists, and headings

## Test plan

- [ ] Send a multi-topic question to the assistant (e.g. "How does our 1st party data targeting work?") and verify the response uses paragraph breaks, bullet points, and headers
- [ ] Verify short single-topic answers still look clean and aren't over-spaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)