### PR TITLE
Fix segment recall: rank by relevance (IDF-weighted), not raw reach

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -6,6 +6,38 @@ future work doesn't have to rediscover it.
 
 ---
 
+## 2026-07-21 — Segment recall: rank by relevance, not raw reach (slice #98)
+
+**What went wrong:** A brief for "gut health" / Yakult surfaced generic food
+segments (Cooking enthusiasts 31M, Foodies Fans) but **omitted the three
+"Gut-Friendly" segments we actually hold** — the single most on-topic audience.
+
+**Why:** Two compounding issues. (1) Generous LLM keyword expansion plus the
+`Food & Drink` category made the keyword gate very loose — ~297 of ~900
+Permutive segments "matched". (2) The selection then ordered purely by **reach
+descending** and capped at 8 per platform. The Gut-Friendly segments are small
+(305k / 127k / 41k) so they sat far below multi-million-reach generic food
+segments and were cut by the cap. The most _relevant_ segment lost to the
+_biggest loosely-relevant_ one.
+
+**How it was fixed:** Rank by **relevance first, reach second**. Each expansion
+keyword gets an inverse-document-frequency weight `log(1 + N/df)` computed over
+the whole catalogue, so a rare, discriminating keyword ("gut", df≈3) far
+outweighs a common one ("food", df≈360). A segment's score is the sum of matched
+keyword weights (×1.5 for a match in the segment _name_). `recommend_segments`
+sorts by `(relevance_score, reach)` before the ≤8 cap. Now Gut-Friendly leads
+the Permutive list and health-relevant segments lead AP; generic giants are
+demoted but still present lower down. See `_keyword_weights` / `_relevance_score`
+in `src/audience.py`.
+
+**Note / tradeoff:** lists are now ordered _most-relevant-first_, so a small
+high-relevance segment can appear above a larger one. That is intentional (the
+product's job is to surface the most relevant audience), but it changes the old
+"ordered by reach desc" display assumption. If a reach-first display is ever
+preferred, select the top-N by relevance but re-sort the chosen set by reach.
+
+---
+
 ## 2026-07-21 — Decision: raw segment .xlsx kept external, not committed (slice #97)
 
 **Context:** The Audience Segments feature builds a canonical `data/segments.csv`

--- a/src/audience.py
+++ b/src/audience.py
@@ -8,6 +8,7 @@ never passes through the LLM.
 """
 import csv
 import json
+import math
 import os
 import re
 
@@ -118,17 +119,53 @@ def _tokenise(text):
     return [_stem(t) for t in re.findall(r"[a-z0-9]+", (text or "").lower())]
 
 
-def _segment_matches_keywords(segment, keywords):
-    """True if any keyword stem appears in the segment's searchable text."""
-    haystack = set(_tokenise(
+def _segment_haystack(segment):
+    """Stemmed token set over a segment's name + description + category."""
+    return set(_tokenise(
         "%s %s %s" % (segment.get("segment_name", ""),
                       segment.get("description", ""),
                       segment.get("category", ""))
     ))
+
+
+def _segment_matches_keywords(segment, keywords):
+    """True if any keyword stem appears in the segment's searchable text."""
+    haystack = _segment_haystack(segment)
     for kw in keywords:
         if set(_tokenise(kw)) & haystack:
             return True
     return False
+
+
+def _keyword_weights(segments, keywords):
+    """Inverse-document-frequency weight per keyword: rarer keywords score higher.
+
+    A keyword like "gut" that matches a handful of segments is far more
+    discriminating than "food", which matches hundreds; weighting by log(N/df)
+    lets a niche, on-topic segment outrank a generic high-reach one.
+    """
+    total = max(len(segments), 1)
+    weights = {}
+    for kw in keywords:
+        kw_stems = set(_tokenise(kw))
+        if not kw_stems:
+            continue
+        df = sum(1 for s in segments if kw_stems & _segment_haystack(s))
+        if df:
+            weights[kw] = math.log(1 + total / df)
+    return weights
+
+
+def _relevance_score(segment, keyword_weights):
+    """Sum of matched keyword weights; matches in the name count for more."""
+    haystack = _segment_haystack(segment)
+    name_stems = set(_tokenise(segment.get("segment_name", "")))
+    score = 0.0
+    for kw, weight in keyword_weights.items():
+        kw_stems = set(_tokenise(kw))
+        if kw_stems & haystack:
+            score += weight * (1.5 if (kw_stems & name_stems) else 1.0)
+    return score
 
 
 def _to_item(segment):
@@ -186,15 +223,23 @@ def recommend_segments(advertiser, topic, client_brief="", segments=None,
     categories = list(expansion.get("categories", [])) if expansion else []
 
     matched = _match_with_fallback(segments, keywords, categories)
+    # Relevance weights are computed over the whole catalogue so a rare, on-topic
+    # keyword ("gut") outweighs a common one ("food"). Segments are then ranked
+    # by relevance first, reach second — so the most relevant niche segments are
+    # never buried under generic high-reach ones (and cut by the per-platform cap).
+    weights = _keyword_weights(segments, keywords)
 
     platforms = []
     for platform in _PLATFORM_ORDER:
-        rows = [_to_item(s) for s in matched if s.get("platform") == platform]
-        rows.sort(key=lambda item: item["reach"], reverse=True)
+        rows = [s for s in matched if s.get("platform") == platform]
+        rows.sort(
+            key=lambda s: (_relevance_score(s, weights), _to_item(s)["reach"]),
+            reverse=True,
+        )
         platforms.append({
             "platform": platform,
             "framing": _PLATFORM_FRAMING[platform],
-            "segments": rows[:per_platform_limit],
+            "segments": [_to_item(s) for s in rows[:per_platform_limit]],
         })
 
     has_any = any(p["segments"] for p in platforms)

--- a/tests/test_audience.py
+++ b/tests/test_audience.py
@@ -205,6 +205,35 @@ def test_lurpak_literal_misses_but_expansion_resolves():
     assert "Dairy Free Fans" in names
 
 
+def test_specific_low_reach_segment_beats_generic_high_reach():
+    # A niche segment matching a RARE keyword ("gut") must be selected over
+    # generic segments matching a COMMON keyword ("food"), even though the
+    # generic ones have far higher reach. Relevance gates before reach.
+    segs = [
+        {"segment_name": "Gut-Friendly Fans", "platform": "Permutive", "reach": "40000",
+         "category": "Food & Drink", "description": "browsed for gut friendly content",
+         "plain_english": "Browses gut-friendly content", "code": "1",
+         "frequency": "R", "window": "All Time", "icon_key": "food-drink"},
+    ]
+    # 10 generic, huge-reach food segments that only match the common keyword.
+    segs += [
+        {"segment_name": "Food Fans %d" % i, "platform": "Permutive",
+         "reach": str(1000000 + i), "category": "Food & Drink",
+         "description": "browsed for food content", "plain_english": "Browses food",
+         "code": str(100 + i), "frequency": "R", "window": "All Time",
+         "icon_key": "food-drink"}
+        for i in range(10)
+    ]
+    payload = recommend_segments(
+        advertiser="Yakult", topic="gut health", segments=segs,
+        expansion={"keywords": ["gut", "food"], "categories": []},
+    )
+    perm = payload["platforms"][1]["segments"]
+    names = [s["segment_name"] for s in perm]
+    assert "Gut-Friendly Fans" in names  # survived the ≤8 cap on relevance
+    assert perm[0]["segment_name"] == "Gut-Friendly Fans"  # ranked most relevant first
+
+
 def test_matching_is_stem_based_not_just_exact():
     # Keyword "baking" should still match a segment whose text only says "bakers"
     # (shared stem "bak"), so wording drift doesn't silently drop a relevant segment.


### PR DESCRIPTION
A "gut health" / Yakult brief omitted the Gut-Friendly segments we hold: loose keyword+category matching produced ~297 candidates, and pure reach-desc ordering
+ the ≤8 cap buried the small (305k/127k/41k) on-topic segments under generic multi-million-reach food segments.

Rank by relevance first, reach second: each expansion keyword gets an IDF weight log(1 + N/df) over the catalogue, so a rare keyword ("gut", df≈3) outweighs a common one ("food", df≈360); segment score sums matched keyword weights (×1.5 for a name match). Gut-Friendly now leads Permutive; health-relevant segments lead AP; generic giants are demoted but retained. TDD: new relevance test; existing reach-desc test still holds (reach is the tiebreak at equal relevance). 346 passed.