### PR TITLE
Slice #104: Deterministic normalised entity match for campaign history

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -6,6 +6,30 @@ future work doesn't have to rediscover it.
 
 ---
 
+## 2026-07-21 — Entity resolution: token-set match, not substring (slice #104)
+
+**What went wrong:** The campaign-history lookup used a case-insensitive
+_substring_ match (`search in advertiser.lower()`). This produced false
+positives — querying "Sky" matched "Skyscanner" and wrongly implied a client
+relationship — and false negatives (legal-suffix / punctuation variants like
+"Tesco Ltd." matched nothing). For a self-serve salesperson with no analyst in
+the loop, a false "yes, they're a client" is the worst failure.
+
+**How it was fixed:** New pure module `src/entity_resolution.py` with
+`resolve(brand, roster)`. Normalisation (lowercase, strip legal suffixes
+Ltd/Plc/Inc, strip punctuation, `&`→`and`) then a **token-set ratio** (à la
+rapidfuzz, implemented on stdlib `difflib` so the module stays dependency-free
+and exhaustively testable). Threshold `MATCH_THRESHOLD = 88`.
+
+**The key insight:** a token-set ratio scores a _whole-token subset_ at 100
+("Jaguar" ⊂ "Jaguar Landrover" → match) but scores a _partial-word overlap_
+low ("sky" vs "skyscanner" share no whole token → 46 → no match). That single
+property gives us the true-positive on abbreviations AND the false-positive
+guard, which substring matching could never do. `campaign_history` now resolves
+against the distinct-advertiser roster and filters by the exact matched name,
+returning `status` ∈ {match, no_match}. Prompt section renamed
+"Previous Campaign History" → "Client Relationship", wording scoped to "direct".
+
 ## 2026-07-21 — Segment recall: rank by relevance, not raw reach (slice #98)
 
 **What went wrong:** A brief for "gut health" / Yakult surfaced generic food

--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -1138,12 +1138,12 @@ export default function InsightsTool() {
                           </CollapsiblePanel>
                         )}
 
-                      {/* Campaign History panel */}
+                      {/* Client Relationship panel */}
                       {result.campaign_history &&
                         result.campaign_history !==
-                          "No previous campaign data found for this advertiser." && (
+                          "No direct campaign history with this advertiser." && (
                           <CollapsiblePanel
-                            title="Campaign History"
+                            title="Client Relationship"
                             defaultOpen={false}
                           >
                             <p className="text-on-surface-variant text-sm leading-relaxed whitespace-pre-wrap">

--- a/src/campaign_history.py
+++ b/src/campaign_history.py
@@ -1,38 +1,59 @@
 import csv
 import os
 
+from src.entity_resolution import resolve
+
 DEFAULT_CSV_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "campaign_history.csv")
 
-NO_DATA_MESSAGE = "No previous campaign data found for this advertiser."
+# Scoped to "direct": the dataset is direct-only, so we never claim to know
+# about programmatic activity and never assert "we've never advertised".
+NO_DATA_MESSAGE = "No direct campaign history with this advertiser."
+
+
+def _no_match_result():
+    # type: () -> dict
+    return {
+        "summary": NO_DATA_MESSAGE,
+        "campaigns": [],
+        "status": "no_match",
+        "matched_name": None,
+    }
 
 
 def get_campaign_summary(advertiser, csv_path=None):
     # type: (str, str) -> dict
     """Look up an advertiser's campaign history and return a summary.
 
-    Returns a dict with:
+    Resolution is deterministic (see ``src.entity_resolution``): the queried
+    advertiser is matched against the roster of canonical advertiser names,
+    never by crude substring. Returns a dict with:
         summary (str): prompt-ready formatted summary
         campaigns (list): raw campaign records (one per campaign ID)
+        status (str): "match" or "no_match"
+        matched_name (str|None): the canonical roster name on a match
     """
     if csv_path is None:
         csv_path = DEFAULT_CSV_PATH
 
     if not os.path.exists(csv_path):
-        return {"summary": NO_DATA_MESSAGE, "campaigns": []}
+        return _no_match_result()
 
     with open(csv_path, newline="") as f:
         reader = csv.DictReader(f)
         rows = list(reader)
 
     if not rows:
-        return {"summary": NO_DATA_MESSAGE, "campaigns": []}
+        return _no_match_result()
 
-    # Filter rows matching advertiser (case-insensitive substring)
-    search = advertiser.lower()
-    matched = [r for r in rows if search in r.get("advertiser", "").lower()]
+    # Resolve the queried advertiser against the roster of canonical names.
+    roster = sorted({r.get("advertiser", "") for r in rows if r.get("advertiser")})
+    resolution = resolve(advertiser, roster)
 
-    if not matched:
-        return {"summary": NO_DATA_MESSAGE, "campaigns": []}
+    if resolution["status"] != "match":
+        return _no_match_result()
+
+    matched_name = resolution["matched_name"]
+    matched = [r for r in rows if r.get("advertiser", "") == matched_name]
 
     # Aggregate by campaign_id to avoid counting individual placements
     campaigns = {}
@@ -76,7 +97,7 @@ def get_campaign_summary(advertiser, csv_path=None):
 
     # Format summary
     summary_lines = [
-        "Campaign history for '%s':" % advertiser,
+        "Direct campaign history for '%s':" % matched_name,
         "- Total campaigns: %d" % len(campaign_list),
         "- Categories: %s" % (", ".join(categories) if categories else "N/A"),
         "- Total impressions: %s" % _format_number(total_impressions),
@@ -90,6 +111,8 @@ def get_campaign_summary(advertiser, csv_path=None):
     return {
         "summary": "\n".join(summary_lines),
         "campaigns": campaign_list,
+        "status": "match",
+        "matched_name": matched_name,
     }
 
 

--- a/src/entity_resolution.py
+++ b/src/entity_resolution.py
@@ -1,0 +1,101 @@
+"""Deterministic entity resolution for the campaign-history lookup.
+
+Pure module: no LLM, no I/O. Answers "have we run a direct campaign with
+this advertiser?" by normalising the queried brand name and token-set
+fuzzy-matching it against a roster of canonical advertiser names.
+
+Public interface:
+    normalise_name(name) -> str
+    resolve(brand, roster) -> {"status", "matched_name", "candidates"}
+
+`status` is one of {"match", "no_match"} in this slice.
+
+Uses only the standard library (difflib) so the module stays pure and
+dependency-free, which is what makes it exhaustively testable.
+"""
+
+import re
+from difflib import SequenceMatcher
+
+# Score (0-100) at or above which a candidate is a confident match.
+MATCH_THRESHOLD = 88
+
+# Legal suffixes / corporate-form tokens stripped during normalisation so
+# "Tesco Ltd" resolves to "Tesco". Kept small and conservative.
+_LEGAL_SUFFIXES = {
+    "ltd", "limited", "plc", "inc", "incorporated", "llc", "llp",
+    "co", "corp", "corporation", "gmbh", "ag", "sa", "bv", "pty",
+}
+
+_PUNCT_RE = re.compile(r"[^a-z0-9\s]")
+_WS_RE = re.compile(r"\s+")
+
+
+def normalise_name(name):
+    # type: (str) -> str
+    """Canonicalise a brand name for comparison.
+
+    Lowercases, normalises ``&`` to ``and``, strips punctuation, and drops
+    legal-suffix tokens (Ltd/Plc/Inc/...). Returns a whitespace-collapsed
+    string of significant tokens.
+    """
+    text = (name or "").lower()
+    text = text.replace("&", " and ")
+    text = _PUNCT_RE.sub(" ", text)
+    text = _WS_RE.sub(" ", text).strip()
+
+    tokens = [t for t in text.split(" ") if t and t not in _LEGAL_SUFFIXES]
+    return " ".join(tokens)
+
+
+def _ratio(a, b):
+    # type: (str, str) -> float
+    if not a and not b:
+        return 1.0
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def _token_set_ratio(a, b):
+    # type: (str, str) -> float
+    """Token-set similarity in [0, 100], after rapidfuzz's approach.
+
+    A full-token subset (e.g. "jaguar" vs "jaguar landrover") scores 100,
+    while partial-word overlaps that don't share a whole token (e.g. "sky"
+    vs "skyscanner") stay low.
+    """
+    tokens_a = set(a.split())
+    tokens_b = set(b.split())
+    if not tokens_a or not tokens_b:
+        return 0.0
+
+    intersection = " ".join(sorted(tokens_a & tokens_b))
+    combined_a = " ".join(sorted(tokens_a & tokens_b) + sorted(tokens_a - tokens_b)).strip()
+    combined_b = " ".join(sorted(tokens_a & tokens_b) + sorted(tokens_b - tokens_a)).strip()
+
+    best = max(
+        _ratio(intersection, combined_a),
+        _ratio(intersection, combined_b),
+        _ratio(combined_a, combined_b),
+    )
+    return best * 100.0
+
+
+def _score(brand, candidate):
+    # type: (str, str) -> float
+    return _token_set_ratio(normalise_name(brand), normalise_name(candidate))
+
+
+def resolve(brand, roster):
+    # type: (str, list) -> dict
+    """Resolve a queried brand against the roster of canonical names.
+
+    Returns a dict with ``status`` (match / no_match), the ``matched_name``
+    on a confident match, and a ``candidates`` list (unused in this slice).
+    """
+    scored = [(candidate, _score(brand, candidate)) for candidate in roster]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+
+    if scored and scored[0][1] >= MATCH_THRESHOLD:
+        return {"status": "match", "matched_name": scored[0][0], "candidates": []}
+
+    return {"status": "no_match", "matched_name": None, "candidates": []}

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -27,8 +27,13 @@ A detailed factual summary of who the advertiser is, grounded in the research pr
 - Any relevant parent company or group context
 Draw from ALL the advertiser research sections (company overview, strategy, recent news). Do not speculate beyond what the research supports. Include source links where the research provides them.
 
-## Previous Campaign History
-If the advertiser has previous campaign history with us, summarise the relationship: how many campaigns, which categories, overall performance, and what worked best. Reference specific past campaigns when making recommendations — e.g. suggest building on formats or categories that performed well previously. Note how recently they last worked with us to frame the relationship (active partner vs. returning client). If no campaign history is available, note this and proceed based on other data sources.
+## Client Relationship
+The factual relationship status is determined **deterministically** and supplied to you in the Campaign History data below — treat it as ground truth and never assert a relationship it does not state.
+
+- If the data gives a **direct campaign history** summary for this advertiser, they are an existing **direct** client: summarise the relationship — how many campaigns, which categories, overall performance, and what worked best. Reference specific past campaigns when making recommendations (e.g. build on formats or categories that performed well). Note how recently they last worked with us to frame the relationship (active partner vs. returning client).
+- If the data states **"No direct campaign history"**, render exactly that scoped framing. Do **not** escalate it to "we have never advertised with this brand" — the dataset is direct-only, so a programmatic relationship may still exist. Then proceed based on the other data sources.
+
+Always scope the wording to **"direct"** campaigns; never over-claim beyond what this direct-only data supports.
 
 ## Editorial Insights
 Key themes and opportunities identified from editor interviews. Reference specific editors and publications.
@@ -126,7 +131,7 @@ The following is the full catalogue of available ad formats with performance ben
 ---
 
 ### Campaign History
-The following is the advertiser's previous campaign history with us. Use this to build the Previous Campaign History section and to inform recommendations.
+The following is the advertiser's **direct** campaign history with us, resolved deterministically. Use this to build the Client Relationship section and to inform recommendations. Treat its factual status (a direct history summary, or "No direct campaign history") as ground truth.
 
 {campaign_history}
 

--- a/tests/test_campaign_history.py
+++ b/tests/test_campaign_history.py
@@ -88,6 +88,48 @@ def test_case_insensitive_match():
         assert len(result["campaigns"]) == 2
 
 
+def test_match_exposes_status_and_matched_name():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path)
+
+        result = get_campaign_summary("Tesco", csv_path)
+
+        assert result["status"] == "match"
+        assert result["matched_name"] == "Tesco"
+
+
+def test_substring_false_positive_now_no_match():
+    """The old substring match returned Skyscanner for "Sky"; the resolver
+    must not — "Sky" shares no whole token with "Skyscanner"."""
+    rows = [
+        {
+            "advertiser": "Skyscanner",
+            "campaign_name": "Skyscanner Summer",
+            "campaign_id": "500",
+            "category": "Travel",
+            "start_date": "2025-05-01",
+            "impressions": "1000000",
+            "clicks": "2000",
+        },
+    ]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path, rows=rows)
+
+        result = get_campaign_summary("Sky", csv_path)
+
+        assert result["status"] == "no_match"
+        assert result["campaigns"] == []
+        assert result["summary"] == NO_DATA_MESSAGE
+
+
+def test_no_direct_wording_on_no_match():
+    """No-match wording is scoped to 'direct', never an absolute claim."""
+    assert "direct" in NO_DATA_MESSAGE.lower()
+    assert "never" not in NO_DATA_MESSAGE.lower()
+
+
 def test_no_match_returns_fallback():
     with tempfile.TemporaryDirectory() as tmpdir:
         csv_path = os.path.join(tmpdir, "campaigns.csv")

--- a/tests/test_entity_resolution.py
+++ b/tests/test_entity_resolution.py
@@ -1,0 +1,72 @@
+"""Tests for the deterministic entity-resolution module.
+
+The resolver is a pure function over data: no LLM, no I/O. These tests
+exercise its public interface (`resolve` / `normalise_name`) and assert
+observable behaviour — the three highest-risk properties being the
+confident match, the false-positive guard, and suffix/punctuation
+normalisation.
+"""
+
+from src.entity_resolution import resolve, normalise_name
+
+ROSTER = [
+    "Tesco",
+    "Aldi",
+    "Jaguar Landrover",
+    "Skyscanner",
+    "BBC Good Food",
+    "Coca-Cola",
+]
+
+
+def test_confident_exact_match():
+    result = resolve("Tesco", ROSTER)
+
+    assert result["status"] == "match"
+    assert result["matched_name"] == "Tesco"
+
+
+def test_token_subset_matches():
+    # "Jaguar" is a full-token subset of "Jaguar Landrover" — same brand.
+    result = resolve("Jaguar", ROSTER)
+
+    assert result["status"] == "match"
+    assert result["matched_name"] == "Jaguar Landrover"
+
+
+def test_false_positive_guard_sky_not_skyscanner():
+    # The headline false positive from the old substring match. "Sky" shares
+    # no whole token with "Skyscanner", so it must NOT resolve to it.
+    result = resolve("Sky", ROSTER)
+
+    assert result["status"] == "no_match"
+    assert result["matched_name"] is None
+
+
+def test_legal_suffix_normalisation():
+    # "Tesco Ltd." with a trailing suffix + punctuation resolves to "Tesco".
+    result = resolve("Tesco Ltd.", ROSTER)
+
+    assert result["status"] == "match"
+    assert result["matched_name"] == "Tesco"
+
+
+def test_punctuation_normalisation():
+    # "Coca Cola" (no hyphen) resolves to the hyphenated roster entry.
+    result = resolve("Coca Cola", ROSTER)
+
+    assert result["status"] == "match"
+    assert result["matched_name"] == "Coca-Cola"
+
+
+def test_ampersand_normalisation():
+    result = normalise_name("Marks & Spencer") == normalise_name("Marks and Spencer")
+    assert result is True
+
+
+def test_genuine_no_match():
+    result = resolve("Netflix", ROSTER)
+
+    assert result["status"] == "no_match"
+    assert result["matched_name"] is None
+    assert result["candidates"] == []

--- a/tests/test_synthesiser.py
+++ b/tests/test_synthesiser.py
@@ -75,13 +75,16 @@ def test_system_prompt_at_a_glance_has_fixed_labels():
     assert "Top Format" in glance_section
 
 
-def test_system_prompt_has_campaign_history_section():
-    """SYSTEM_PROMPT should contain a Previous Campaign History section after Advertiser Overview."""
-    assert "Previous Campaign History" in SYSTEM_PROMPT
-    history_pos = SYSTEM_PROMPT.index("Previous Campaign History")
+def test_system_prompt_has_client_relationship_section():
+    """SYSTEM_PROMPT should contain a Client Relationship section (scoped to
+    "direct" campaigns) after Advertiser Overview and before Editorial Insights."""
+    assert "Client Relationship" in SYSTEM_PROMPT
+    history_pos = SYSTEM_PROMPT.index("Client Relationship")
     overview_pos = SYSTEM_PROMPT.index("Advertiser Overview")
     editorial_pos = SYSTEM_PROMPT.index("Editorial Insights")
     assert overview_pos < history_pos < editorial_pos
+    # Wording is scoped to "direct" and never an absolute no-relationship claim.
+    assert "direct" in SYSTEM_PROMPT[history_pos:editorial_pos].lower()
 
 
 def test_system_prompt_has_client_brief_instruction():


### PR DESCRIPTION
Replace the case-insensitive substring match with a pure, dependency-free entity-resolution module (src/entity_resolution.py). Normalises names (lowercase, strip legal suffixes/punctuation, &→and) and token-set fuzzy-matches against the roster with a threshold, returning a two-state status (match / no_match).

- Kills the "Sky"→"Skyscanner" false positive (no shared whole token)
- Resolves legal-suffix/punctuation variants ("Tesco Ltd." → "Tesco")
- campaign_history resolves against the distinct-advertiser roster and filters by exact matched name; exposes status + matched_name
- Prompt section renamed to "Client Relationship", wording scoped to "direct"; no-match renders "No direct campaign history"
- Frontend panel gate + title updated to match

Tests (pure module): confident match, false-positive guard, suffix/ punctuation normalisation, ampersand, genuine no-match.