### PR TITLE
Slice #105: Vertical normalisation at ingest

### DIFF
--- a/data/brand_verticals.csv
+++ b/data/brand_verticals.csv
@@ -1,0 +1,218 @@
+brand,vertical,source,needs_review
+AA,Motoring,seed,false
+AEG,Entertainment,seed,false
+AMEX,Finance,seed,false
+ASDA,Supermarket,seed,false
+Abarth,Motoring,seed,false
+Abbott,Food & Drink,seed,false
+Age of Elegance,Entertainment,seed,false
+Agency Press Ltd T/A Sold Out Advertising,Entertainment,seed,false
+Aldi,Supermarket,seed,false
+Alfa Romeo,Motoring,seed,false
+Alpen,Food & Drink,seed,false
+Alpine,Motoring,seed,false
+American Pistachio,Food & Drink,seed,false
+Angelcare,Parenting,seed,false
+Apple,Entertainment,seed,false
+Arla,Food & Drink,seed,false
+Arla Lurpak,Food & Drink,seed,false
+Asda,Food & Drink,seed,false
+Astus,Food & Drink,seed,false
+Audible,Entertainment,seed,false
+Autoglym Perfect Partners,Motoring,seed,false
+Avios,Travel,seed,false
+Aviva,Health,seed,false
+B&M,Food & Drink,seed,false
+BBC Good Food,Food & Drink,seed,false
+BMW,Motoring,seed,false
+BSskyb,Entertainment,seed,false
+BYD,Motoring,seed,false
+Barclays,Government,seed,false
+Barretine Spring + Summer GW,Home & Garden,seed,false
+Bart Ingredients,Food & Drink,seed,false
+Beko,Technology,seed,false
+BioGaia,Parenting,seed,false
+Birds Eye,Food & Drink,seed,false
+Bisodol,Food & Drink,seed,false
+Bletchley Park,Entertainment,seed,false
+Bloomsbury,Entertainment,seed,false
+Bloomsbury - Emperor Of Seas,Entertainment,seed,false
+Bloomsbury - Jon Watts,Entertainment,seed,false
+Bloomsbury - Poppy Cooks,Entertainment,seed,false
+Bolsover Cruises,Travel,seed,false
+Box,Parenting,seed,false
+Brown Forman + El Jimador,Alcohol,seed,false
+CNIEL,Food & Drink,seed,false
+Carte D'Or,Food & Drink,seed,false
+Castello,Food & Drink,seed,false
+Centrum,Health,seed,false
+Ceres Walnuts,Food & Drink,seed,false
+Chery,Motoring,seed,false
+Cost Cutter,Food & Drink,seed,false
+Crowded House,Entertainment,seed,false
+Cupra,Motoring,seed,false
+Cuprinol,Health,seed,false
+Currys Blink,Entertainment,seed,false
+Dacia,Motoring,seed,false
+Damart,Retail,seed,false
+Damart - Black Friday,Supermarket,seed,false
+David Austin Roses,Home & Garden,seed,false
+David Essex,Entertainment,seed,false
+De'Longhi,Food & Drink,seed,false
+De'longi,Food & Drink,seed,false
+Diageo,Alcohol,seed,false
+Disney+,Entertainment,seed,false
+Dr Brown,Parenting,seed,false
+E.ON,Technology,seed,false
+E.ON Smart Energy,Technology,seed,false
+Eco Manure,Home & Garden,seed,false
+Ecofurb,Entertainment,seed,false
+Electorial Commission,Government,seed,false
+Energizer,Motoring,seed,false
+European Mushrooms,Food & Drink,seed,false
+Filippo Berrio,Food & Drink,seed,false
+Finish,Food & Drink,seed,false
+Florette,Food & Drink,seed,false
+Ford,Motoring,seed,false
+Fortnum and Mason,Retail,seed,false
+Fortum & Mason,Food & Drink,seed,false
+Gousto,Food & Drink,seed,false
+Grana Padano,Food & Drink,seed,false
+Great Rail Journeys,Travel,seed,false
+HBO Max,Entertainment,seed,false
+Haier,Food & Drink,seed,false
+Hays OctNov,Travel,seed,false
+Hays Travel,Travel,seed,false
+Hays Travel - Feb,Travel,seed,false
+Hays Travel - Jan 2025,Travel,seed,false
+Hays Travel - June,Travel,seed,false
+Hays Travel - May,Travel,seed,false
+Hendricks,Alcohol,seed,false
+Holiday Property Bond,Travel,seed,false
+Holland & Barrett,Health,seed,false
+Hu Chocolate,Food & Drink,seed,false
+Hurtigruten,Travel,seed,false
+Hyundai Motor (UK),Motoring,seed,false
+ITV,Entertainment,seed,false
+If You Care,Food & Drink,seed,false
+Immediate Media,Retail,seed,false
+Inspired Villages Group Limited,Entertainment,seed,false
+Itsu,Food & Drink,seed,false
+Jaguar Landrover,Motoring,seed,false
+Jason's Sourdough,Food & Drink,seed,false
+Kerrygold,Food & Drink,seed,false
+Kikkoman,Food & Drink,seed,false
+Knorrr,Food & Drink,seed,false
+La Vieja Fábrica,Food & Drink,seed,false
+Laithwaites,Alcohol,seed,false
+Lego UK,Parenting,seed,false
+Lidl,Supermarket,seed,false
+Life Health Foods,Parenting,seed,false
+Linwoods,Food & Drink,seed,false
+Live Nation,Entertainment,seed,false
+Long Clawson,Food & Drink,seed,false
+Marks & Spencer,Food & Drink,seed,false
+Mars,Food & Drink,seed,false
+Marti Pellow,Food & Drink,seed,false
+Mattel UK,Entertainment,seed,false
+Merchant Gourmet,Food & Drink,seed,false
+Miller & Carter,Food & Drink,seed,false
+Morrisons,Supermarket,seed,false
+My Expert Midwife,Parenting,seed,false
+NOW TV,Entertainment,seed,false
+Nacon,Gaming,seed,false
+Nacon - Rugby '25,Gaming,seed,false
+National Geographic,Entertainment,seed,false
+National Theatre,Entertainment,seed,false
+Nestle - Maggi,Food & Drink,seed,false
+Nestle Purina,Pets,seed,false
+Ninja,Technology,seed,false
+Nintendo,Gaming,seed,false
+Nissan,Motoring,seed,false
+Norwegian Seafood,Food & Drink,seed,false
+Not On The High Street,Entertainment,seed,false
+Nutracheck,Entertainment,seed,false
+OOONO,Entertainment,seed,false
+ORD-00288785_Opportunity Direct - Itsu_Yonder_Product Launch_Sept 2024,Food & Drink,seed,false
+ORD-00290307 Microsoft Consumer // Direct // Dentsu // 4th Nov - 17th Jan,Technology,seed,false
+Ocado,Parenting,seed,false
+Omada,Motoring,seed,false
+Outfit 7,Gaming,seed,false
+Outfit 7 - Hank Anniversary,Gaming,seed,false
+Oxford University Press,Entertainment,seed,false
+P&O Cruises,Travel,seed,false
+Pack'd,Food & Drink,seed,false
+Paramount+,Entertainment,seed,false
+Pearson Education Limited,Entertainment,seed,false
+Pearson Examiner,Parenting,seed,false
+Penfolds,Alcohol,seed,false
+Pernod Ricard,Alcohol,seed,false
+Peter Nyssen,Home & Garden,seed,false
+Peugeot,Motoring,seed,false
+Piccolo,Food & Drink,seed,false
+Pink Lady,Food & Drink,seed,false
+Playseat,Gaming,seed,false
+Positec Worx,Home & Garden,seed,false
+Post Office,Government,seed,false
+President Cream,Food & Drink,seed,false
+Primula,Food & Drink,seed,false
+Primula - Easter,Food & Drink,seed,false
+Princess Cruises,Travel,seed,false
+Profile Books,Entertainment,seed,false
+Quickline Broadband,Technology,seed,false
+Radio Times Marketting,Entertainment,seed,false
+Rare & Pasture,Food & Drink,seed,false
+Red Tractor,Food & Drink,seed,false
+Regina,Food & Drink,seed,false
+Renault,Motoring,seed,false
+Ristorante,Food & Drink,seed,false
+River Street Events,Home & Garden,seed,false
+Rowse,Food & Drink,seed,false
+Ruth Strauss,Health,seed,false
+Ruth Strauss Foundation,Health,seed,false
+Saga,Travel,seed,false
+Sainsburys,Food & Drink,seed,false
+Sarson's,Food & Drink,seed,false
+Screw This Podcast - House Campaign,Entertainment,seed,false
+Skoda,Motoring,seed,false
+Sky,Entertainment,seed,false
+Soberano,Alcohol,seed,false
+Sold Out,Entertainment,seed,false
+Specsavers,Health,seed,false
+Spinnaker London,Food & Drink,seed,false
+Spode,Food & Drink,seed,false
+St Ewe,Food & Drink,seed,false
+Stake,Gambling,seed,false
+Suma Wholefoods,Food & Drink,seed,false
+Superdrug,Health,seed,false
+TUI,Travel,seed,false
+TV5 Monde,Entertainment,seed,false
+Tesco,Supermarket,seed,false
+Thames and Hudson // D-Day Atlas - Charles Messenger,Entertainment,seed,false
+The Baby Show,Parenting,seed,false
+The Crown Estate,Food & Drink,seed,false
+The Professional Framing Company,Entertainment,seed,false
+The Royal Mint,Food & Drink,seed,false
+The Walt Disney Company,Entertainment,seed,false
+Ticketmaster,Entertainment,seed,false
+Tom Kerridge,Entertainment,seed,false
+Toyota,Motoring,seed,false
+Transport for Wales Rail,Travel,seed,false
+Turtle Wax,Motoring,seed,false
+Twix,Food & Drink,seed,false
+Universal Pictures,Entertainment,seed,false
+Uzbekistan Food Festival,Food & Drink,seed,false
+Uzbekistan Travel,Travel,seed,false
+Visa,Retail,seed,false
+Visit Orlando,Travel,seed,false
+Waitrose,Supermarket,seed,false
+Wargaming Group Ltd,Gaming,seed,false
+Warner - Tom Kerridge,Entertainment,seed,false
+Warner Brothers,Entertainment,seed,false
+Warner Hotels,Travel,seed,false
+Warner Leisure,Travel,seed,false
+Webb,Home & Garden,seed,false
+Winalot,Pets,seed,false
+Windsor Castle,Entertainment,seed,false
+bet365,Gambling,seed,false
+shell,Motoring,seed,false

--- a/data/vertical_taxonomy.json
+++ b/data/vertical_taxonomy.json
@@ -1,0 +1,18 @@
+[
+  "Food & Drink",
+  "Alcohol",
+  "Supermarket",
+  "Entertainment",
+  "Travel",
+  "Motoring",
+  "Technology",
+  "Health",
+  "Finance",
+  "Gambling",
+  "Gaming",
+  "Government",
+  "Parenting",
+  "Home & Garden",
+  "Retail",
+  "Pets"
+]

--- a/ingest.py
+++ b/ingest.py
@@ -6,6 +6,35 @@ import os
 
 from src.embeddings import chunk_transcript, get_embeddings
 from src.vectorstore import add_chunks
+from src.vertical_classifier import (
+    DEFAULT_LOOKUP_PATH,
+    distinct_brands_with_hints,
+    load_taxonomy,
+    refresh_brand_verticals,
+    classify_new_brands_llm,
+)
+
+
+def refresh_verticals():
+    """Diff the campaign-history roster against the cached brand->vertical
+    lookup, LLM-classify any new brands, and flag additions for review."""
+    roster, hints = distinct_brands_with_hints()
+    if not roster:
+        print("No campaign history found; skipping vertical classification.")
+        return
+
+    taxonomy = load_taxonomy()
+    result = refresh_brand_verticals(
+        roster, hints, taxonomy, DEFAULT_LOOKUP_PATH, classify_new_brands_llm
+    )
+
+    if result["flagged"]:
+        print("\nNew brands classified and FLAGGED FOR REVIEW (%d):"
+              % len(result["flagged"]))
+        for brand in result["flagged"]:
+            print("  - %s -> %s" % (brand, result["lookup"].get(brand, "?")))
+    else:
+        print("\nNo new brands to classify — brand->vertical cache is current.")
 
 
 def main():
@@ -34,6 +63,9 @@ def main():
     add_chunks(all_chunks, embeddings)
 
     print(f"\nDone! Ingested {len(files)} transcripts, {len(all_chunks)} chunks.")
+
+    print("\nRefreshing brand->vertical lookup...")
+    refresh_verticals()
 
 
 if __name__ == "__main__":

--- a/scripts/seed_brand_verticals.py
+++ b/scripts/seed_brand_verticals.py
@@ -1,0 +1,56 @@
+"""One-off seed generator for the vertical taxonomy + brand->vertical lookup.
+
+Deterministic (no LLM): reads data/campaign_history.csv, writes
+data/vertical_taxonomy.json and data/brand_verticals.csv. Every roster brand
+is seeded from its modal raw category where that category maps to a controlled
+vertical; brands whose modal category is junk/unmappable are written with a
+blank vertical and flagged (needs_review=true) for Matt to fill in.
+
+Re-run after a data refresh to regenerate the seed, then review flagged rows.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.vertical_classifier import (  # noqa: E402
+    SEED_TAXONOMY,
+    DEFAULT_TAXONOMY_PATH,
+    DEFAULT_LOOKUP_PATH,
+    LOOKUP_FIELDNAMES,
+    distinct_brands_with_hints,
+    seed_vertical_from_category,
+    save_brand_verticals,
+)
+
+
+def main():
+    with open(DEFAULT_TAXONOMY_PATH, "w") as f:
+        json.dump(SEED_TAXONOMY, f, indent=2)
+        f.write("\n")
+
+    roster, hints = distinct_brands_with_hints()
+    rows = []
+    flagged = 0
+    for brand in roster:
+        vertical = seed_vertical_from_category(hints.get(brand, ""))
+        needs_review = "false" if vertical else "true"
+        if not vertical:
+            flagged += 1
+        rows.append({
+            "brand": brand,
+            "vertical": vertical,
+            "source": "seed",
+            "needs_review": needs_review,
+        })
+
+    save_brand_verticals(DEFAULT_LOOKUP_PATH, rows)
+    print("Wrote taxonomy (%d verticals) to %s" % (len(SEED_TAXONOMY), DEFAULT_TAXONOMY_PATH))
+    print("Wrote %d brands to %s (%d flagged for review)"
+          % (len(rows), DEFAULT_LOOKUP_PATH, flagged))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vertical_classifier.py
+++ b/src/vertical_classifier.py
@@ -1,0 +1,256 @@
+"""Vertical classifier: builds a clean brand->vertical lookup at ingest.
+
+The raw `category` column in campaign_history.csv is treated as permanently
+messy (numeric junk, blanks, one-off labels) and is never reasoned on
+directly. Instead we derive a clean, controlled **vertical taxonomy** and a
+cached brand->vertical lookup, both versioned under `data/`.
+
+At ingest we diff the current roster against the cached lookup, classify any
+**new** brands into the taxonomy (LLM-assisted, using the messy raw category
+only as a hint), append them to the cache, and flag the additions for review.
+
+Design for testability: the new-brand diff is a pure function; the
+classification step takes an injectable `classifier_fn` so tests can stub the
+LLM entirely.
+"""
+
+import csv
+import json
+import os
+from collections import Counter
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
+DEFAULT_TAXONOMY_PATH = os.path.join(DATA_DIR, "vertical_taxonomy.json")
+DEFAULT_LOOKUP_PATH = os.path.join(DATA_DIR, "brand_verticals.csv")
+DEFAULT_CAMPAIGN_CSV = os.path.join(DATA_DIR, "campaign_history.csv")
+
+LOOKUP_FIELDNAMES = ["brand", "vertical", "source", "needs_review"]
+
+# Controlled vertical taxonomy, seeded from the meaningful raw category values.
+# Reviewable/extendable; the raw category column is only ever a hint.
+SEED_TAXONOMY = [
+    "Food & Drink",
+    "Alcohol",
+    "Supermarket",
+    "Entertainment",
+    "Travel",
+    "Motoring",
+    "Technology",
+    "Health",
+    "Finance",
+    "Gambling",
+    "Gaming",
+    "Government",
+    "Parenting",
+    "Home & Garden",
+    "Retail",
+    "Pets",
+]
+
+# Deterministic map from (lowercased) raw category -> controlled vertical, used
+# only to seed the initial cache. Anything not here is left for LLM/review.
+CATEGORY_TO_VERTICAL = {
+    "food": "Food & Drink",
+    "gf": "Food & Drink",
+    "alcohol": "Alcohol",
+    "supermarket": "Supermarket",
+    "entertainment": "Entertainment",
+    "on-demand": "Entertainment",
+    "history": "Entertainment",
+    "social": "Entertainment",
+    "social carousel": "Entertainment",
+    "travel": "Travel",
+    "motoring": "Motoring",
+    "tech": "Technology",
+    "health": "Health",
+    "finance": "Finance",
+    "gambling": "Gambling",
+    "gaming": "Gaming",
+    "government": "Government",
+    "parenting": "Parenting",
+    "gardening": "Home & Garden",
+    "retail": "Retail",
+    "pets": "Pets",
+}
+
+
+def diff_new_brands(roster, cached_lookup):
+    # type: (list, dict) -> list
+    """Return roster brands not already present in the cached lookup.
+
+    Pure function. Order-stable (roster order), so the same input always
+    yields the same list — new brands are never re-detected once cached.
+    """
+    return [brand for brand in roster if brand not in cached_lookup]
+
+
+def load_taxonomy(path=None):
+    # type: (str) -> list
+    """Load the controlled vertical taxonomy (list of vertical names)."""
+    if path is None:
+        path = DEFAULT_TAXONOMY_PATH
+    if not os.path.exists(path):
+        return []
+    with open(path) as f:
+        return json.load(f)
+
+
+def load_brand_verticals(path=None):
+    # type: (str) -> dict
+    """Load the cached brand->vertical lookup as a dict of brand -> vertical."""
+    if path is None:
+        path = DEFAULT_LOOKUP_PATH
+    if not os.path.exists(path):
+        return {}
+    lookup = {}
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            lookup[row["brand"]] = row["vertical"]
+    return lookup
+
+
+def save_brand_verticals(path, lookup_rows):
+    # type: (str, list) -> None
+    """Write the brand->vertical cache (list of full row dicts) to CSV."""
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=LOOKUP_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(lookup_rows)
+
+
+def _read_lookup_rows(path):
+    # type: (str) -> list
+    if not os.path.exists(path):
+        return []
+    with open(path, newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def refresh_brand_verticals(roster, category_hints, taxonomy, lookup_path, classifier_fn):
+    # type: (list, dict, list, str, callable) -> dict
+    """Diff the roster against the cache, classify new brands, persist, flag.
+
+    - ``roster``: current distinct advertiser names.
+    - ``category_hints``: brand -> raw category, passed to the classifier as a
+      hint only (never trusted as the vertical).
+    - ``taxonomy``: controlled list of allowed verticals.
+    - ``lookup_path``: brand->vertical cache CSV (read and rewritten in place).
+    - ``classifier_fn(brands, category_hints, taxonomy) -> {brand: vertical}``:
+      injectable so tests stub the LLM.
+
+    Only brands absent from the cache are classified (so the same brand is not
+    re-classified every run). Added brands are flagged for review. Returns
+    ``{"added": [...], "flagged": [...], "lookup": {brand: vertical}}``.
+    """
+    existing_rows = _read_lookup_rows(lookup_path)
+    cached = {row["brand"]: row["vertical"] for row in existing_rows}
+
+    new_brands = diff_new_brands(roster, cached)
+
+    classified = classifier_fn(new_brands, category_hints, taxonomy) if new_brands else {}
+
+    added = []
+    for brand in new_brands:
+        vertical = classified.get(brand)
+        if not vertical:
+            continue  # classifier declined this brand; leave it for next run
+        existing_rows.append({
+            "brand": brand,
+            "vertical": vertical,
+            "source": "llm",
+            "needs_review": "true",
+        })
+        added.append(brand)
+
+    save_brand_verticals(lookup_path, existing_rows)
+
+    lookup = {row["brand"]: row["vertical"] for row in existing_rows}
+    return {"added": added, "flagged": list(added), "lookup": lookup}
+
+
+def distinct_brands_with_hints(csv_path=None):
+    # type: (str) -> tuple
+    """Read campaign_history and return (roster, hints).
+
+    ``roster`` is the sorted distinct advertiser names; ``hints`` maps each
+    brand to its **modal** raw category (the single most common category label
+    across that brand's rows) — used only as a classification hint.
+    """
+    if csv_path is None:
+        csv_path = DEFAULT_CAMPAIGN_CSV
+    if not os.path.exists(csv_path):
+        return [], {}
+
+    categories_by_brand = {}
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            brand = (row.get("advertiser") or "").strip()
+            if not brand:
+                continue
+            categories_by_brand.setdefault(brand, Counter())
+            category = (row.get("category") or "").strip()
+            if category:
+                categories_by_brand[brand][category] += 1
+
+    roster = sorted(categories_by_brand)
+    hints = {}
+    for brand, counter in categories_by_brand.items():
+        hints[brand] = counter.most_common(1)[0][0] if counter else ""
+    return roster, hints
+
+
+def seed_vertical_from_category(raw_category):
+    # type: (str) -> str
+    """Map a raw category to a controlled vertical, or "" if unmappable."""
+    return CATEGORY_TO_VERTICAL.get((raw_category or "").strip().lower(), "")
+
+
+def classify_new_brands_llm(brands, category_hints, taxonomy):
+    # type: (list, dict, list) -> dict
+    """Default classifier: ask the chat model to place each brand in the
+    controlled taxonomy, using the raw category only as a hint.
+
+    Returns {brand: vertical}; any vertical the model returns that is not in
+    the taxonomy is dropped, so the cache can only ever hold controlled values.
+    Not unit-tested (raw LLM call) — the Python logic around it is.
+    """
+    if not brands:
+        return {}
+
+    from openai import OpenAI
+    import config
+
+    lines = []
+    for brand in brands:
+        hint = category_hints.get(brand, "")
+        lines.append("- %s (raw category hint: %s)" % (brand, hint or "none"))
+
+    prompt = (
+        "Classify each advertiser brand into exactly one vertical from this "
+        "controlled list:\n%s\n\nBrands:\n%s\n\n"
+        "Return ONLY a JSON object mapping each brand name (verbatim) to one "
+        "vertical from the list. The raw category hint is messy — use your own "
+        "knowledge of the brand as the primary signal."
+        % (", ".join(taxonomy), "\n".join(lines))
+    )
+
+    client = OpenAI(api_key=config.OPENAI_API_KEY)
+    response = client.chat.completions.create(
+        model=config.CHAT_MODEL,
+        messages=[
+            {"role": "system", "content": "You are a precise brand-vertical classifier. Output only JSON."},
+            {"role": "user", "content": prompt},
+        ],
+        temperature=0.0,
+        response_format={"type": "json_object"},
+    )
+
+    try:
+        raw = json.loads(response.choices[0].message.content)
+    except (ValueError, TypeError):
+        return {}
+
+    allowed = set(taxonomy)
+    return {b: v for b, v in raw.items() if b in brands and v in allowed}

--- a/tests/test_vertical_classifier.py
+++ b/tests/test_vertical_classifier.py
@@ -1,0 +1,139 @@
+"""Tests for the vertical classifier (ingest-time brand→vertical lookup).
+
+The new-brand diff is a pure function and is tested directly. The
+classification orchestration is tested with the LLM classifier stubbed —
+we verify the Python logic (diff, caching, flagging), never model output.
+"""
+
+import os
+import csv
+import json
+import tempfile
+
+from src.vertical_classifier import (
+    diff_new_brands,
+    refresh_brand_verticals,
+    load_brand_verticals,
+    seed_vertical_from_category,
+    distinct_brands_with_hints,
+)
+
+
+def test_diff_new_brands_detects_uncached():
+    roster = ["Tesco", "Aldi", "Monzo"]
+    cached = {"Tesco": "Supermarket", "Aldi": "Supermarket"}
+
+    new = diff_new_brands(roster, cached)
+
+    assert new == ["Monzo"]
+
+
+def _seed_lookup(path, rows):
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["brand", "vertical", "source", "needs_review"]
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_refresh_classifies_only_new_brands_and_flags_them():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lookup_path = os.path.join(tmpdir, "brand_verticals.csv")
+        _seed_lookup(
+            lookup_path,
+            [{"brand": "Tesco", "vertical": "Supermarket",
+              "source": "seed", "needs_review": "false"}],
+        )
+
+        roster = ["Tesco", "Monzo", "Revolut"]
+        hints = {"Tesco": "Supermarket", "Monzo": "Finance", "Revolut": "Finance"}
+        taxonomy = ["Supermarket", "Finance"]
+
+        seen = {}
+
+        def fake_classifier(brands, category_hints, tax):
+            seen["brands"] = list(brands)
+            return {b: "Finance" for b in brands}
+
+        result = refresh_brand_verticals(
+            roster, hints, taxonomy, lookup_path, fake_classifier
+        )
+
+        # Cached brand is never re-classified (deterministic / cheap refresh).
+        assert set(seen["brands"]) == {"Monzo", "Revolut"}
+        # New brands are added and flagged for review.
+        assert set(result["added"]) == {"Monzo", "Revolut"}
+        assert set(result["flagged"]) == {"Monzo", "Revolut"}
+        # Cache file now holds all three brands.
+        assert load_brand_verticals(lookup_path) == {
+            "Tesco": "Supermarket",
+            "Monzo": "Finance",
+            "Revolut": "Finance",
+        }
+
+
+def test_refresh_is_idempotent():
+    """A second refresh with the same roster classifies nothing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lookup_path = os.path.join(tmpdir, "brand_verticals.csv")
+        _seed_lookup(
+            lookup_path,
+            [{"brand": "Tesco", "vertical": "Supermarket",
+              "source": "seed", "needs_review": "false"}],
+        )
+        roster = ["Tesco", "Monzo"]
+        hints = {"Tesco": "Supermarket", "Monzo": "Finance"}
+        taxonomy = ["Supermarket", "Finance"]
+
+        def classifier(brands, category_hints, tax):
+            return {b: "Finance" for b in brands}
+
+        refresh_brand_verticals(roster, hints, taxonomy, lookup_path, classifier)
+
+        calls = {"n": 0}
+
+        def counting_classifier(brands, category_hints, tax):
+            calls["n"] += len(list(brands))
+            return {b: "Finance" for b in brands}
+
+        result = refresh_brand_verticals(
+            roster, hints, taxonomy, lookup_path, counting_classifier
+        )
+
+        assert calls["n"] == 0
+        assert result["added"] == []
+
+
+def test_seed_vertical_maps_known_category_and_rejects_junk():
+    assert seed_vertical_from_category("Food") == "Food & Drink"
+    assert seed_vertical_from_category("gambling") == "Gambling"
+    # Junk / numeric / unknown categories map to nothing (left for review).
+    assert seed_vertical_from_category("1972520") == ""
+    assert seed_vertical_from_category("") == ""
+
+
+def test_distinct_brands_with_hints_uses_modal_category():
+    rows = [
+        {"advertiser": "Acme", "category": "Food", "campaign_id": "1",
+         "campaign_name": "a", "start_date": "2025-01-01",
+         "impressions": "1", "clicks": "0"},
+        {"advertiser": "Acme", "category": "Food", "campaign_id": "2",
+         "campaign_name": "b", "start_date": "2025-01-01",
+         "impressions": "1", "clicks": "0"},
+        {"advertiser": "Acme", "category": "1972520", "campaign_id": "3",
+         "campaign_name": "c", "start_date": "2025-01-01",
+         "impressions": "1", "clicks": "0"},
+    ]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        with open(csv_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(rows)
+
+        roster, hints = distinct_brands_with_hints(csv_path)
+
+        assert roster == ["Acme"]
+        # "Food" appears twice, the junk category once -> modal is "Food".
+        assert hints["Acme"] == "Food"


### PR DESCRIPTION
Adds a controlled brand->vertical lookup so the comparables engine (later slices) has a clean vertical to filter on, instead of the permanently-messy raw category column.

- New module src/vertical_classifier.py: pure new-brand diff, injectable LLM classifier, cache read/write. Only brands absent from the cache are classified (deterministic, cheap refresh); additions are flagged for review.
- Controlled taxonomy data/vertical_taxonomy.json (16 verticals) + cached lookup data/brand_verticals.csv (217 brands), both versioned under data/.
- scripts/seed_brand_verticals.py regenerates the seed deterministically (no LLM) from modal raw category; junk/numeric categories are left blank and flagged.
- ingest.py runs refresh_brand_verticals after transcript ingest and prints newly-classified brands for review.

Tests (LLM stubbed): new-brand diff, classify-only-new + flagging, idempotent re-run, seed category mapping, modal-hint extraction.