### PR TITLE
Slice #109: Add the possible-match band (three-state resolver)

### DIFF
--- a/src/campaign_history.py
+++ b/src/campaign_history.py
@@ -17,7 +17,71 @@ def _no_match_result():
         "campaigns": [],
         "status": "no_match",
         "matched_name": None,
+        "candidates": [],
     }
+
+
+def _aggregate_campaigns(rows):
+    # type: (list) -> list
+    """Aggregate rows for a single brand by campaign_id into campaign records."""
+    campaigns = {}
+    for row in rows:
+        cid = row.get("campaign_id", "")
+        impressions = int(row.get("impressions", 0) or 0)
+        clicks = int(row.get("clicks", 0) or 0)
+
+        if cid in campaigns:
+            campaigns[cid]["impressions"] += impressions
+            campaigns[cid]["clicks"] += clicks
+        else:
+            campaigns[cid] = {
+                "campaign_id": cid,
+                "campaign_name": row.get("campaign_name", "Unknown"),
+                "category": row.get("category", "Unknown"),
+                "start_date": row.get("start_date", "Unknown"),
+                "impressions": impressions,
+                "clicks": clicks,
+            }
+    return list(campaigns.values())
+
+
+def _best_campaign(campaign_list):
+    # type: (list) -> tuple
+    """Return (best_campaign, best_ctr) by CTR, impressions as tiebreaker."""
+    def _ctr_sort_key(c):
+        ctr = (c["clicks"] / c["impressions"] * 100) if c["impressions"] > 0 else 0.0
+        return (ctr, c["impressions"])
+
+    best = max(campaign_list, key=_ctr_sort_key)
+    best_ctr = (best["clicks"] / best["impressions"] * 100) if best["impressions"] > 0 else 0.0
+    return best, best_ctr
+
+
+def _summarise_brand(brand_name, campaign_list, header=None):
+    # type: (str, list, str) -> str
+    """Produce a prompt-ready summary block for one brand's campaigns."""
+    total_impressions = sum(c["impressions"] for c in campaign_list)
+    total_clicks = sum(c["clicks"] for c in campaign_list)
+    avg_ctr = (total_clicks / total_impressions * 100) if total_impressions > 0 else 0.0
+
+    categories = sorted(set(c["category"] for c in campaign_list if c["category"] != "Unknown"))
+    most_recent = max(campaign_list, key=lambda c: c["start_date"])
+    best, best_ctr = _best_campaign(campaign_list)
+
+    if header is None:
+        header = "Direct campaign history for '%s':" % brand_name
+
+    return "\n".join([
+        header,
+        "- Total campaigns: %d" % len(campaign_list),
+        "- Categories: %s" % (", ".join(categories) if categories else "N/A"),
+        "- Total impressions: %s" % _format_number(total_impressions),
+        "- Average CTR: %.2f%%" % avg_ctr,
+        "- Most recent campaign: %s (%s)" % (most_recent["campaign_name"], most_recent["start_date"]),
+        "- Best performing: %s (%.2f%% CTR, %s impressions)" % (
+            best["campaign_name"], best_ctr, _format_number(best["impressions"])
+        ),
+    ])
 
 
 def get_campaign_summary(advertiser, csv_path=None):
@@ -29,8 +93,9 @@ def get_campaign_summary(advertiser, csv_path=None):
     never by crude substring. Returns a dict with:
         summary (str): prompt-ready formatted summary
         campaigns (list): raw campaign records (one per campaign ID)
-        status (str): "match" or "no_match"
-        matched_name (str|None): the canonical roster name on a match
+        status (str): "match", "possible_match", or "no_match"
+        matched_name (str|None): the canonical roster name on a confident match
+        candidates (list): names to verify, on a possible_match
     """
     if csv_path is None:
         csv_path = DEFAULT_CSV_PATH
@@ -48,71 +113,58 @@ def get_campaign_summary(advertiser, csv_path=None):
     # Resolve the queried advertiser against the roster of canonical names.
     roster = sorted({r.get("advertiser", "") for r in rows if r.get("advertiser")})
     resolution = resolve(advertiser, roster)
+    status = resolution["status"]
 
-    if resolution["status"] != "match":
+    if status == "no_match":
         return _no_match_result()
 
+    if status == "possible_match":
+        return _possible_match_result(resolution["candidates"], rows)
+
+    # Confident match.
     matched_name = resolution["matched_name"]
     matched = [r for r in rows if r.get("advertiser", "") == matched_name]
-
-    # Aggregate by campaign_id to avoid counting individual placements
-    campaigns = {}
-    for row in matched:
-        cid = row.get("campaign_id", "")
-        impressions = int(row.get("impressions", 0) or 0)
-        clicks = int(row.get("clicks", 0) or 0)
-
-        if cid in campaigns:
-            campaigns[cid]["impressions"] += impressions
-            campaigns[cid]["clicks"] += clicks
-        else:
-            campaigns[cid] = {
-                "campaign_id": cid,
-                "campaign_name": row.get("campaign_name", "Unknown"),
-                "category": row.get("category", "Unknown"),
-                "start_date": row.get("start_date", "Unknown"),
-                "impressions": impressions,
-                "clicks": clicks,
-            }
-
-    campaign_list = list(campaigns.values())
-
-    # Compute aggregates
-    total_impressions = sum(c["impressions"] for c in campaign_list)
-    total_clicks = sum(c["clicks"] for c in campaign_list)
-    avg_ctr = (total_clicks / total_impressions * 100) if total_impressions > 0 else 0.0
-
-    categories = sorted(set(c["category"] for c in campaign_list if c["category"] != "Unknown"))
-
-    # Most recent campaign
-    most_recent = max(campaign_list, key=lambda c: c["start_date"])
-
-    # Best campaign by CTR (impressions as tiebreaker)
-    def _ctr_sort_key(c):
-        ctr = (c["clicks"] / c["impressions"] * 100) if c["impressions"] > 0 else 0.0
-        return (ctr, c["impressions"])
-
-    best = max(campaign_list, key=_ctr_sort_key)
-    best_ctr = (best["clicks"] / best["impressions"] * 100) if best["impressions"] > 0 else 0.0
-
-    # Format summary
-    summary_lines = [
-        "Direct campaign history for '%s':" % matched_name,
-        "- Total campaigns: %d" % len(campaign_list),
-        "- Categories: %s" % (", ".join(categories) if categories else "N/A"),
-        "- Total impressions: %s" % _format_number(total_impressions),
-        "- Average CTR: %.2f%%" % avg_ctr,
-        "- Most recent campaign: %s (%s)" % (most_recent["campaign_name"], most_recent["start_date"]),
-        "- Best performing: %s (%.2f%% CTR, %s impressions)" % (
-            best["campaign_name"], best_ctr, _format_number(best["impressions"])
-        ),
-    ]
+    campaign_list = _aggregate_campaigns(matched)
 
     return {
-        "summary": "\n".join(summary_lines),
+        "summary": _summarise_brand(matched_name, campaign_list),
         "campaigns": campaign_list,
         "status": "match",
         "matched_name": matched_name,
+        "candidates": [],
+    }
+
+
+def _possible_match_result(candidates, rows):
+    # type: (list, list) -> dict
+    """Render the ambiguous state: a ⚠ verify callout naming each candidate
+    with its history, asserting no confirmed relationship. Comparables are
+    suppressed for this state (handled downstream)."""
+    blocks = [
+        "⚠ POSSIBLE MATCH — VERIFY BEFORE CLAIMING A RELATIONSHIP.",
+        "The queried advertiser is ambiguous. We are not asserting a direct "
+        "relationship. These roster brands are possible matches — confirm which "
+        "(if any) is the client before referencing any history:",
+    ]
+    for candidate in candidates:
+        candidate_rows = [r for r in rows if r.get("advertiser", "") == candidate]
+        campaign_list = _aggregate_campaigns(candidate_rows)
+        if campaign_list:
+            blocks.append(
+                _summarise_brand(
+                    candidate, campaign_list,
+                    header="Candidate '%s' (direct history — unverified):" % candidate,
+                )
+            )
+        else:
+            blocks.append("Candidate '%s': no direct campaign history on record." % candidate)
+
+    return {
+        "summary": "\n\n".join(blocks),
+        "campaigns": [],
+        "status": "possible_match",
+        "matched_name": None,
+        "candidates": list(candidates),
     }
 
 

--- a/src/entity_resolution.py
+++ b/src/entity_resolution.py
@@ -19,6 +19,9 @@ from difflib import SequenceMatcher
 
 # Score (0-100) at or above which a candidate is a confident match.
 MATCH_THRESHOLD = 88
+# Score band [POSSIBLE_THRESHOLD, MATCH_THRESHOLD) is the ambiguous "verify"
+# zone. Also, several candidates at/above MATCH_THRESHOLD is ambiguous.
+POSSIBLE_THRESHOLD = 72
 
 # Legal suffixes / corporate-form tokens stripped during normalisation so
 # "Tesco Ltd" resolves to "Tesco". Kept small and conservative.
@@ -89,13 +92,34 @@ def resolve(brand, roster):
     # type: (str, list) -> dict
     """Resolve a queried brand against the roster of canonical names.
 
-    Returns a dict with ``status`` (match / no_match), the ``matched_name``
-    on a confident match, and a ``candidates`` list (unused in this slice).
+    Three-way outcome:
+      - ``match`` — one confident winner (exact normalised hit, or a single
+        candidate at/above ``MATCH_THRESHOLD``). ``matched_name`` is set.
+      - ``possible_match`` — ambiguous: either several strong candidates
+        (e.g. "Virgin" → Virgin Media / Virgin Atlantic) or a single
+        mid-band near-miss. ``matched_name`` is ``None`` and ``candidates``
+        lists the names to verify; we assert nothing.
+      - ``no_match`` — nothing crosses the possible band.
     """
+    normalised_brand = normalise_name(brand)
+
+    # An exact normalised hit is unambiguous and wins over subset candidates
+    # (so "Sky" resolves to "Sky", not to "Sky Betting And Gaming").
+    for candidate in roster:
+        if normalise_name(candidate) == normalised_brand and normalised_brand:
+            return {"status": "match", "matched_name": candidate, "candidates": []}
+
     scored = [(candidate, _score(brand, candidate)) for candidate in roster]
     scored.sort(key=lambda pair: pair[1], reverse=True)
 
-    if scored and scored[0][1] >= MATCH_THRESHOLD:
-        return {"status": "match", "matched_name": scored[0][0], "candidates": []}
+    strong = [name for name, score in scored if score >= MATCH_THRESHOLD]
+    in_band = [name for name, score in scored if score >= POSSIBLE_THRESHOLD]
+
+    if len(strong) == 1:
+        return {"status": "match", "matched_name": strong[0], "candidates": []}
+
+    if in_band:
+        # Multiple strong candidates, or a single mid-band near-miss: ambiguous.
+        return {"status": "possible_match", "matched_name": None, "candidates": in_band}
 
     return {"status": "no_match", "matched_name": None, "candidates": []}

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -28,10 +28,11 @@ A detailed factual summary of who the advertiser is, grounded in the research pr
 Draw from ALL the advertiser research sections (company overview, strategy, recent news). Do not speculate beyond what the research supports. Include source links where the research provides them.
 
 ## Client Relationship
-The factual relationship status is determined **deterministically** and supplied to you in the Campaign History data below — treat it as ground truth and never assert a relationship it does not state.
+The factual relationship status is determined **deterministically** and supplied to you in the Campaign History data below — treat it as ground truth and never assert a relationship it does not state. The data will be in exactly one of three states:
 
-- If the data gives a **direct campaign history** summary for this advertiser, they are an existing **direct** client: summarise the relationship — how many campaigns, which categories, overall performance, and what worked best. Reference specific past campaigns when making recommendations (e.g. build on formats or categories that performed well). Note how recently they last worked with us to frame the relationship (active partner vs. returning client).
-- If the data states **"No direct campaign history"**, render exactly that scoped framing. Do **not** escalate it to "we have never advertised with this brand" — the dataset is direct-only, so a programmatic relationship may still exist. Then proceed based on the other data sources.
+- **Direct campaign history summary present** → they are an existing **direct** client: summarise the relationship — how many campaigns, which categories, overall performance, and what worked best. Reference specific past campaigns when making recommendations (e.g. build on formats or categories that performed well). Note how recently they last worked with us to frame the relationship (active partner vs. returning client).
+- **A "⚠ POSSIBLE MATCH — VERIFY" callout** → the advertiser name is ambiguous. Render the callout faithfully: name the candidate brand(s) and show their history exactly as given, but **assert no confirmed relationship** — tell the reader to verify which candidate (if any) is the client. Do **not** pick one and claim it. Do **not** offer comparable/similar brands in this state.
+- **"No direct campaign history"** → render exactly that scoped framing. Do **not** escalate it to "we have never advertised with this brand" — the dataset is direct-only, so a programmatic relationship may still exist. Then proceed based on the other data sources.
 
 Always scope the wording to **"direct"** campaigns; never over-claim beyond what this direct-only data supports.
 

--- a/tests/test_campaign_history.py
+++ b/tests/test_campaign_history.py
@@ -124,6 +124,47 @@ def test_substring_false_positive_now_no_match():
         assert result["summary"] == NO_DATA_MESSAGE
 
 
+def test_possible_match_renders_verify_callout():
+    """An ambiguous query flags candidates to verify, asserts nothing, and
+    shows each candidate's history."""
+    rows = [
+        {
+            "advertiser": "Virgin Media",
+            "campaign_name": "VM Broadband",
+            "campaign_id": "600",
+            "category": "Tech",
+            "start_date": "2025-03-01",
+            "impressions": "2000000",
+            "clicks": "5000",
+        },
+        {
+            "advertiser": "Virgin Atlantic",
+            "campaign_name": "VA Summer",
+            "campaign_id": "601",
+            "category": "Travel",
+            "start_date": "2025-06-01",
+            "impressions": "1500000",
+            "clicks": "3000",
+        },
+    ]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path, rows=rows)
+
+        result = get_campaign_summary("Virgin", csv_path)
+
+        assert result["status"] == "possible_match"
+        assert result["matched_name"] is None
+        # Both candidates are named for the salesperson to verify.
+        assert "Virgin Media" in result["summary"]
+        assert "Virgin Atlantic" in result["summary"]
+        # The callout is clearly a verify prompt, not an assertion.
+        assert "verify" in result["summary"].lower()
+        assert "⚠" in result["summary"]
+        # Candidates are exposed structurally too.
+        assert set(result["candidates"]) == {"Virgin Media", "Virgin Atlantic"}
+
+
 def test_no_direct_wording_on_no_match():
     """No-match wording is scoped to 'direct', never an absolute claim."""
     assert "direct" in NO_DATA_MESSAGE.lower()

--- a/tests/test_entity_resolution.py
+++ b/tests/test_entity_resolution.py
@@ -70,3 +70,35 @@ def test_genuine_no_match():
     assert result["status"] == "no_match"
     assert result["matched_name"] is None
     assert result["candidates"] == []
+
+
+# --- Three-state: the ambiguous "possible_match" band (#109) ---
+
+AMBIGUOUS_ROSTER = ["Virgin Media", "Virgin Atlantic", "Tesco", "Audi"]
+
+
+def test_ambiguous_name_is_possible_match_with_candidates():
+    # "Virgin" is a whole-token subset of two different roster brands, so we
+    # must not assert either — flag both for the salesperson to verify.
+    result = resolve("Virgin", AMBIGUOUS_ROSTER)
+
+    assert result["status"] == "possible_match"
+    assert result["matched_name"] is None
+    assert set(result["candidates"]) == {"Virgin Media", "Virgin Atlantic"}
+
+
+def test_mid_band_near_miss_is_possible_not_match():
+    # "Aldi" vs "Audi" (~75) is a risky near-miss: flag it, never assert it.
+    result = resolve("Aldi", AMBIGUOUS_ROSTER)
+
+    assert result["status"] == "possible_match"
+    assert result["matched_name"] is None
+    assert result["candidates"] == ["Audi"]
+
+
+def test_exact_match_wins_over_subset_candidates():
+    # An exact normalised hit is confident even when subset candidates exist.
+    result = resolve("Virgin Media", AMBIGUOUS_ROSTER)
+
+    assert result["status"] == "match"
+    assert result["matched_name"] == "Virgin Media"


### PR DESCRIPTION
Extends entity resolution from two-state to match / possible_match / no_match, and renders the ambiguous band as a ⚠ verify callout.

- resolve() now returns possible_match with a candidate list when the name is ambiguous: either several strong candidates ("Virgin" → Virgin Media / Virgin Atlantic, both whole-token subsets) or a single mid-band near-miss ("Aldi" vs "Audi" ~75). An exact normalised hit still wins confidently.
- campaign_history renders a ⚠ "POSSIBLE MATCH — VERIFY" callout naming each candidate with its (unverified) history, asserting nothing; comparables are suppressed in this state. Aggregation refactored into reusable per-brand helpers.
- prompts: Client Relationship section documents all three states, incl. the verify-don't-claim rule and comparables suppression.

Tests: ambiguous multi-candidate → possible_match with correct candidates; mid-band near-miss → possible_match not match; exact-match-wins; and the campaign_history verify-callout rendering.