### PR TITLE
Slice #110: Reactive alias table + unmatched-brand logging

### DIFF
--- a/data/brand_aliases.csv
+++ b/data/brand_aliases.csv
@@ -1,0 +1,1 @@
+alias,canonical

--- a/data/unmatched_brands.csv
+++ b/data/unmatched_brands.csv
@@ -1,0 +1,1 @@
+timestamp,queried_brand,status,candidates

--- a/src/alias_table.py
+++ b/src/alias_table.py
@@ -1,0 +1,74 @@
+"""Artefact I/O for the reactive alias table and the unmatched-brand log.
+
+The alias table (``data/brand_aliases.csv``) is small, manually maintained,
+and NOT pre-populated — entries are added in response to observed misses. The
+unmatched log (``data/unmatched_brands.csv``) records queries that no-matched
+or possible-matched, so the alias table can grow from real misses rather than
+guesswork and to feed the entity-resolution limitations review.
+
+The resolver itself stays pure; this module is the file-facing edge that loads
+the alias dict and appends log rows.
+"""
+
+import csv
+import os
+
+from src.entity_resolution import normalise_name
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
+DEFAULT_ALIASES_PATH = os.path.join(DATA_DIR, "brand_aliases.csv")
+DEFAULT_UNMATCHED_LOG_PATH = os.path.join(DATA_DIR, "unmatched_brands.csv")
+
+LOG_FIELDNAMES = ["timestamp", "queried_brand", "status", "candidates"]
+
+
+def load_aliases(path=None):
+    # type: (str) -> dict
+    """Load the alias table as ``{normalised_alias: canonical_name}``.
+
+    Keys are normalised with the resolver's own ``normalise_name`` so lookups
+    line up. Blank rows are skipped. Missing file → empty dict.
+    """
+    if path is None:
+        path = DEFAULT_ALIASES_PATH
+    if not os.path.exists(path):
+        return {}
+
+    aliases = {}
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            alias = (row.get("alias") or "").strip()
+            canonical = (row.get("canonical") or "").strip()
+            if not alias or not canonical:
+                continue
+            aliases[normalise_name(alias)] = canonical
+    return aliases
+
+
+def log_unmatched(queried_brand, status, candidates=None, path=None, timestamp=None):
+    # type: (str, str, list, str, str) -> None
+    """Append an unmatched / near-matched query to the growth log.
+
+    ``timestamp`` is injectable for deterministic tests; it defaults to the
+    current UTC time. Creates the file (with header) on first write.
+    """
+    if path is None:
+        path = DEFAULT_UNMATCHED_LOG_PATH
+    if timestamp is None:
+        from datetime import datetime, timezone
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+    candidates_str = "; ".join(candidates or [])
+    write_header = not os.path.exists(path)
+
+    with open(path, "a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=LOG_FIELDNAMES)
+        if write_header:
+            writer.writeheader()
+        writer.writerow({
+            "timestamp": timestamp,
+            "queried_brand": queried_brand,
+            "status": status,
+            "candidates": candidates_str,
+        })

--- a/src/campaign_history.py
+++ b/src/campaign_history.py
@@ -2,6 +2,7 @@ import csv
 import os
 
 from src.entity_resolution import resolve
+from src.alias_table import load_aliases, log_unmatched
 
 DEFAULT_CSV_PATH = os.path.join(os.path.dirname(__file__), "..", "data", "campaign_history.csv")
 
@@ -84,13 +85,20 @@ def _summarise_brand(brand_name, campaign_list, header=None):
     ])
 
 
-def get_campaign_summary(advertiser, csv_path=None):
-    # type: (str, str) -> dict
+def get_campaign_summary(advertiser, csv_path=None, aliases=None, log_path=None):
+    # type: (str, str, dict, str) -> dict
     """Look up an advertiser's campaign history and return a summary.
 
     Resolution is deterministic (see ``src.entity_resolution``): the queried
     advertiser is matched against the roster of canonical advertiser names,
-    never by crude substring. Returns a dict with:
+    never by crude substring. A reactive ``aliases`` table (loaded from the
+    default artefact when not supplied) maps known aliases to canonical brands.
+
+    When ``log_path`` is given, no-match / possible-match queries are appended
+    to the unmatched-brand growth log (off by default so tests stay clean; the
+    pipeline enables it).
+
+    Returns a dict with:
         summary (str): prompt-ready formatted summary
         campaigns (list): raw campaign records (one per campaign ID)
         status (str): "match", "possible_match", or "no_match"
@@ -99,6 +107,8 @@ def get_campaign_summary(advertiser, csv_path=None):
     """
     if csv_path is None:
         csv_path = DEFAULT_CSV_PATH
+    if aliases is None:
+        aliases = load_aliases()
 
     if not os.path.exists(csv_path):
         return _no_match_result()
@@ -112,8 +122,12 @@ def get_campaign_summary(advertiser, csv_path=None):
 
     # Resolve the queried advertiser against the roster of canonical names.
     roster = sorted({r.get("advertiser", "") for r in rows if r.get("advertiser")})
-    resolution = resolve(advertiser, roster)
+    resolution = resolve(advertiser, roster, aliases=aliases)
     status = resolution["status"]
+
+    # Log misses / near-misses so the alias table can grow from real data.
+    if log_path and status in ("no_match", "possible_match"):
+        log_unmatched(advertiser, status, resolution.get("candidates", []), path=log_path)
 
     if status == "no_match":
         return _no_match_result()

--- a/src/entity_resolution.py
+++ b/src/entity_resolution.py
@@ -88,8 +88,8 @@ def _score(brand, candidate):
     return _token_set_ratio(normalise_name(brand), normalise_name(candidate))
 
 
-def resolve(brand, roster):
-    # type: (str, list) -> dict
+def resolve(brand, roster, aliases=None):
+    # type: (str, list, dict) -> dict
     """Resolve a queried brand against the roster of canonical names.
 
     Three-way outcome:
@@ -100,8 +100,21 @@ def resolve(brand, roster):
         mid-band near-miss. ``matched_name`` is ``None`` and ``candidates``
         lists the names to verify; we assert nothing.
       - ``no_match`` — nothing crosses the possible band.
+
+    ``aliases`` is an optional dict of ``{normalised_alias: canonical_name}``
+    (a reactive, manually-maintained table). A known alias (e.g. "Coke" →
+    "Coca-Cola") short-circuits to a confident match, provided its canonical
+    is actually on the roster; a stale alias pointing off-roster is ignored.
     """
     normalised_brand = normalise_name(brand)
+
+    # Reactive alias table: a known alias resolves straight to its canonical,
+    # but only if that canonical is genuinely on the roster.
+    if aliases and normalised_brand in aliases:
+        canonical = aliases[normalised_brand]
+        for candidate in roster:
+            if normalise_name(candidate) == normalise_name(canonical):
+                return {"status": "match", "matched_name": candidate, "candidates": []}
 
     # An exact normalised hit is unambiguous and wins over subset candidates
     # (so "Sky" resolves to "Sky", not to "Sky Betting And Gaming").

--- a/src/synthesiser.py
+++ b/src/synthesiser.py
@@ -9,6 +9,7 @@ from src.trends import get_trend_data
 from src.brief import summarise_brief
 from src.formats import load_format_data, load_format_names, validate_format_names
 from src.campaign_history import get_campaign_summary
+from src.alias_table import DEFAULT_UNMATCHED_LOG_PATH
 from src.prompts import SYSTEM_PROMPT, USER_PROMPT_TEMPLATE
 
 logger = logging.getLogger(__name__)
@@ -108,8 +109,9 @@ def generate_insights(
     # 5. Load format recommendations
     format_recommendations = load_format_data()
 
-    # 6. Look up previous campaign history
-    campaign_result = get_campaign_summary(advertiser)
+    # 6. Look up direct campaign history (deterministic resolution). Enable
+    #    miss-logging so the reactive alias table can grow from real queries.
+    campaign_result = get_campaign_summary(advertiser, log_path=DEFAULT_UNMATCHED_LOG_PATH)
     campaign_history = campaign_result["summary"]
 
     # 7. Summarise client brief if provided

--- a/tests/test_alias_table.py
+++ b/tests/test_alias_table.py
@@ -1,0 +1,63 @@
+"""Tests for the alias-table + unmatched-log artefact I/O.
+
+These cover the file-facing helpers: loading the reactive alias table into
+the normalised dict the resolver expects, and appending unmatched /
+near-matched queries to the growth log.
+"""
+
+import os
+import csv
+import tempfile
+
+from src.alias_table import load_aliases, log_unmatched
+
+
+def test_load_aliases_normalises_keys():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "brand_aliases.csv")
+        with open(path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=["alias", "canonical"])
+            writer.writeheader()
+            writer.writerow({"alias": "Coke", "canonical": "Coca-Cola"})
+            writer.writerow({"alias": "", "canonical": ""})  # blank row ignored
+
+        aliases = load_aliases(path)
+
+        # Keys are normalised so the resolver can look them up directly.
+        assert aliases == {"coke": "Coca-Cola"}
+
+
+def test_load_aliases_missing_file_returns_empty():
+    assert load_aliases("/nonexistent/aliases.csv") == {}
+
+
+def test_log_unmatched_appends_row():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "unmatched_brands.csv")
+
+        log_unmatched("Weirdbrand", "no_match", [], path=path, timestamp="2026-07-21T10:00:00")
+        log_unmatched("Virgin", "possible_match",
+                      ["Virgin Media", "Virgin Atlantic"],
+                      path=path, timestamp="2026-07-21T10:05:00")
+
+        with open(path, newline="") as f:
+            rows = list(csv.DictReader(f))
+
+        assert len(rows) == 2
+        assert rows[0]["queried_brand"] == "Weirdbrand"
+        assert rows[0]["status"] == "no_match"
+        assert rows[1]["queried_brand"] == "Virgin"
+        assert rows[1]["status"] == "possible_match"
+        assert "Virgin Media" in rows[1]["candidates"]
+
+
+def test_log_unmatched_creates_file_with_header():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "log.csv")
+
+        log_unmatched("Foo", "no_match", [], path=path, timestamp="2026-07-21T00:00:00")
+
+        assert os.path.exists(path)
+        with open(path, newline="") as f:
+            header = f.readline().strip()
+        assert header == "timestamp,queried_brand,status,candidates"

--- a/tests/test_campaign_history.py
+++ b/tests/test_campaign_history.py
@@ -171,6 +171,46 @@ def test_no_direct_wording_on_no_match():
     assert "never" not in NO_DATA_MESSAGE.lower()
 
 
+def test_alias_hit_resolves_in_campaign_summary():
+    """A supplied alias maps a query to its canonical roster brand."""
+    rows = [
+        {
+            "advertiser": "Coca-Cola",
+            "campaign_name": "Coke Summer",
+            "campaign_id": "700",
+            "category": "Food",
+            "start_date": "2025-05-01",
+            "impressions": "3000000",
+            "clicks": "9000",
+        },
+    ]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        _create_test_csv(csv_path, rows=rows)
+
+        result = get_campaign_summary("Coke", csv_path, aliases={"coke": "Coca-Cola"})
+
+        assert result["status"] == "match"
+        assert result["matched_name"] == "Coca-Cola"
+
+
+def test_no_match_is_logged_when_log_path_given():
+    """A genuine miss is appended to the unmatched-brand growth log."""
+    import csv as _csv
+    with tempfile.TemporaryDirectory() as tmpdir:
+        csv_path = os.path.join(tmpdir, "campaigns.csv")
+        log_path = os.path.join(tmpdir, "unmatched.csv")
+        _create_test_csv(csv_path)
+
+        get_campaign_summary("TotallyUnknownBrand", csv_path, log_path=log_path)
+
+        assert os.path.exists(log_path)
+        with open(log_path, newline="") as f:
+            logged = list(_csv.DictReader(f))
+        assert any(r["queried_brand"] == "TotallyUnknownBrand"
+                   and r["status"] == "no_match" for r in logged)
+
+
 def test_no_match_returns_fallback():
     with tempfile.TemporaryDirectory() as tmpdir:
         csv_path = os.path.join(tmpdir, "campaigns.csv")

--- a/tests/test_entity_resolution.py
+++ b/tests/test_entity_resolution.py
@@ -102,3 +102,23 @@ def test_exact_match_wins_over_subset_candidates():
 
     assert result["status"] == "match"
     assert result["matched_name"] == "Virgin Media"
+
+
+# --- Reactive alias table (#110) ---
+
+def test_alias_resolves_to_canonical_brand():
+    # "Coke" shares no token with "Coca-Cola" and would otherwise no-match;
+    # the alias table maps it to the canonical roster brand.
+    aliases = {"coke": "Coca-Cola"}
+    result = resolve("Coke", ROSTER, aliases=aliases)
+
+    assert result["status"] == "match"
+    assert result["matched_name"] == "Coca-Cola"
+
+
+def test_stale_alias_pointing_off_roster_is_ignored():
+    # An alias whose canonical is not on the roster must not fabricate a match.
+    aliases = {"coke": "Pepsi"}
+    result = resolve("Coke", ROSTER, aliases=aliases)
+
+    assert result["status"] == "no_match"


### PR DESCRIPTION
Adds a manually-maintained, reactive alias table and a growth log so the entity resolver improves from real observed misses.

- resolve() takes an optional aliases dict {normalised_alias: canonical}; a known alias ("Coke" → "Coca-Cola") short-circuits to a confident match, but only if the canonical is genuinely on the roster (stale aliases ignored).
- New I/O module src/alias_table.py: load_aliases() (normalises keys for the resolver) and log_unmatched() (append no-match/possible-match queries; injectable timestamp for deterministic tests).
- campaign_history loads aliases (default artefact) and, when a log_path is given, logs misses/near-misses; synthesiser enables logging in production.
- Versioned artefacts under data/: brand_aliases.csv (header only — NOT pre-populated) and unmatched_brands.csv (header only).

Tests: alias hit → canonical, stale alias ignored (pure); load_aliases normalisation + missing file, log append + header creation; and alias hit / miss-logging through get_campaign_summary.