### PR TITLE
Disable editorial/vector search (Phase 2) + restructure prompt

### DIFF
--- a/src/prompts.py
+++ b/src/prompts.py
@@ -1,17 +1,16 @@
-SYSTEM_PROMPT = """You are a strategic insights analyst for a media company's commercial team. Your role is to synthesise editorial expertise, brand research, audience data, and market trends into actionable recommendations for advertising clients.
+SYSTEM_PROMPT = """You are a strategic insights analyst for a media company's commercial team. Your role is to synthesise brand research, audience data, and market trends into actionable recommendations for advertising clients.
 
 Your output should be structured, evidence-based, and commercially focused. Write in a professional but accessible tone suitable for a client-facing brief.
 
 Structure your response with these sections:
 
 ## At a Glance
-Produce exactly 6 one-line summaries using the fixed labels below. Each line must follow the format `Label: Content` — one per line, no bullets, no numbering. Keep each to a single concise sentence.
+Produce exactly 5 one-line summaries using the fixed labels below. Each line must follow the format `Label: Content` — one per line, no bullets, no numbering. Keep each to a single concise sentence.
 
 Core Products: [what the advertiser sells — their key products or services]
 Latest News: [one recent development, campaign, or announcement]
 Messaging: [one-line recommended messaging direction]
 Tone: [one-line recommended creative tone]
-Editor Voice: [one standout quote or insight from the editorial data]
 Top Format: [the single best ad format recommendation with key metric]
 
 ## Key Recommendations
@@ -36,11 +35,8 @@ The factual relationship status is determined **deterministically** and supplied
 
 Always scope the wording to **"direct"** campaigns; never over-claim beyond what this direct-only data supports.
 
-## Editorial Insights
-Key themes and opportunities identified from editor interviews. Reference specific editors and publications.
-
 ## Strategic Alignment
-How the advertiser's stated goals, challenges, and recent activity connect to the editorial insights. Identify specific opportunities where the advertiser's strategy aligns with editorial themes.
+How the advertiser's stated goals, challenges, and recent activity connect to the audience data, market trends, and brand research provided. Identify specific opportunities where the advertiser's strategy aligns with what the data shows.
 
 ## Audience Segments & Reach
 Recommend the most relevant targetable audience segments for this brief, based on the Audience Segments & Reach data provided. The data is split by platform (AP = modelled first-party audience, broad reach; Permutive = behavioural, recently engaged browsers) — present them as two separate lists, each in its own scale, and state the one-line framing for each so a broad modelled audience is never oversold as precise intent.
@@ -68,7 +64,7 @@ Use this KPI-to-objective mapping when selecting formats:
 - Viewability → prioritise formats with the highest viewability scores regardless of stated objective
 - Clicks → prioritise formats with the highest CTR and Direct response as primary objective
 
-After the list, close the section with a single **combined rationale** — one short paragraph (not per-format) that ties the chosen set together against *this* specific advertiser and KPI. Amalgamate the chosen formats' `best_for_brief` and `best_for_advertiser_type` guidance along with the available editorial and audience context, so the rationale reads as a tailored strategic story rather than boilerplate. Reference the advertiser by name and the stated KPI explicitly.
+After the list, close the section with a single **combined rationale** — one short paragraph (not per-format) that ties the chosen set together against *this* specific advertiser and KPI. Amalgamate the chosen formats' `best_for_brief` and `best_for_advertiser_type` guidance along with the available audience context, so the rationale reads as a tailored strategic story rather than boilerplate. Reference the advertiser by name and the stated KPI explicitly.
 
 If no format recommendation data is available, note this explicitly.
 
@@ -76,7 +72,7 @@ If no format recommendation data is available, note this explicitly.
 Specific recommendations for campaign messaging, tone, and creative direction. Tailor all recommendations to support the advertiser's stated KPI. For each recommendation, explain how it serves that specific KPI objective.
 
 For each recommendation:
-- Tie it to specific evidence from the data (editorial quotes, audience data points, trend signals, or brand research findings)
+- Tie it to specific evidence from the data (audience data points, trend signals, or brand research findings)
 - Explain how it aligns with the advertiser's known strategy, campaigns, or brand values from the research
 - Include 2-3 concrete creative examples for each recommendation — sample headlines, CTAs, or copy lines that a creative team could use as a starting point. These should feel specific to the advertiser and topic, not generic
 - Where the research includes source links, include them as references so the reader can verify the evidence
@@ -95,13 +91,6 @@ USER_PROMPT_TEMPLATE = """Generate a strategic insights brief for the following:
 
 ### Client Brief
 {client_brief}
-
----
-
-### Editorial Intelligence
-The following excerpts are from interviews with editors at our publications. Use these as the foundation for your recommendations.
-
-{editorial_insights}
 
 ---
 

--- a/src/synthesiser.py
+++ b/src/synthesiser.py
@@ -2,7 +2,10 @@ import logging
 
 from openai import OpenAI
 import config
-from src.vectorstore import search_transcripts
+# NOTE: Editorial vector search disabled for now (Phase 2). The vector-DB
+# layer (src.vectorstore / src.embeddings / ingest.py) is left intact and
+# dormant; re-enable by restoring the import and the search call below.
+# from src.vectorstore import search_transcripts
 from src.web_search import research_advertiser
 from src.audience import expand_query, recommend_segments, format_audience_segments
 from src.trends import get_trend_data
@@ -122,9 +125,9 @@ def generate_insights(
     Returns dict with keys: content, sources, research_skills,
     audience_segments, google_trends.
     """
-    # 1. Search vector DB for editorial insights
-    results = search_transcripts(topic, n_results=5)
-    editorial_insights, sources = _format_editorial_insights(results)
+    # 1. Editorial vector search disabled for now (Phase 2). `sources` stays an
+    #    empty list so the return contract is unchanged for the API/frontend.
+    sources = []
 
     # 2. Skill-based advertiser research
     skill_results = research_advertiser(advertiser)
@@ -166,7 +169,6 @@ def generate_insights(
         topic=topic,
         advertiser=advertiser,
         advertiser_kpi=kpi,
-        editorial_insights=editorial_insights,
         advertiser_research=advertiser_research,
         audience_segments=audience_segments_text,
         google_trends=google_trends,

--- a/tests/test_synthesiser.py
+++ b/tests/test_synthesiser.py
@@ -15,7 +15,9 @@ def test_system_prompt_not_empty():
 def test_system_prompt_has_key_sections():
     assert "Advertiser Overview" in SYSTEM_PROMPT
     assert "Strategic Alignment" in SYSTEM_PROMPT
-    assert "Editorial Insights" in SYSTEM_PROMPT
+    # Editorial Insights section removed while editorial vector search is
+    # disabled (Phase 2).
+    assert "Editorial Insights" not in SYSTEM_PROMPT
 
 
 def test_system_prompt_has_key_recommendations_section():
@@ -63,7 +65,8 @@ def test_system_prompt_at_a_glance_is_before_key_recommendations():
 
 
 def test_system_prompt_at_a_glance_has_fixed_labels():
-    """At a Glance section should reference all 6 fixed labels."""
+    """At a Glance section should reference all fixed labels (Editor Voice
+    removed while editorial vector search is disabled — Phase 2)."""
     glance_start = SYSTEM_PROMPT.index("At a Glance")
     key_recs_start = SYSTEM_PROMPT.index("Key Recommendations")
     glance_section = SYSTEM_PROMPT[glance_start:key_recs_start]
@@ -71,20 +74,20 @@ def test_system_prompt_at_a_glance_has_fixed_labels():
     assert "Latest News" in glance_section
     assert "Messaging" in glance_section
     assert "Tone" in glance_section
-    assert "Editor Voice" in glance_section
+    assert "Editor Voice" not in glance_section
     assert "Top Format" in glance_section
 
 
 def test_system_prompt_has_client_relationship_section():
     """SYSTEM_PROMPT should contain a Client Relationship section (scoped to
-    "direct" campaigns) after Advertiser Overview and before Editorial Insights."""
+    "direct" campaigns) after Advertiser Overview and before Strategic Alignment."""
     assert "Client Relationship" in SYSTEM_PROMPT
     history_pos = SYSTEM_PROMPT.index("Client Relationship")
     overview_pos = SYSTEM_PROMPT.index("Advertiser Overview")
-    editorial_pos = SYSTEM_PROMPT.index("Editorial Insights")
-    assert overview_pos < history_pos < editorial_pos
+    alignment_pos = SYSTEM_PROMPT.index("Strategic Alignment")
+    assert overview_pos < history_pos < alignment_pos
     # Wording is scoped to "direct" and never an absolute no-relationship claim.
-    assert "direct" in SYSTEM_PROMPT[history_pos:editorial_pos].lower()
+    assert "direct" in SYSTEM_PROMPT[history_pos:alignment_pos].lower()
 
 
 def test_system_prompt_has_client_brief_instruction():
@@ -177,7 +180,8 @@ def test_system_prompt_messaging_section_references_kpi():
 def test_user_prompt_template_has_placeholders():
     assert "{topic}" in USER_PROMPT_TEMPLATE
     assert "{advertiser}" in USER_PROMPT_TEMPLATE
-    assert "{editorial_insights}" in USER_PROMPT_TEMPLATE
+    # {editorial_insights} placeholder removed while editorial is disabled.
+    assert "{editorial_insights}" not in USER_PROMPT_TEMPLATE
     assert "{advertiser_research}" in USER_PROMPT_TEMPLATE
     assert "{audience_segments}" in USER_PROMPT_TEMPLATE
     assert "{google_trends}" in USER_PROMPT_TEMPLATE
@@ -192,7 +196,6 @@ def test_user_prompt_renders():
         topic="test topic",
         advertiser="test brand",
         advertiser_kpi="Awareness",
-        editorial_insights="some insights",
         advertiser_research="some research",
         audience_segments="some segments",
         google_trends="some trends",
@@ -228,14 +231,12 @@ def test_generate_insights_accepts_kpi_and_injects_into_prompt():
         ],
     }
 
-    with patch("src.synthesiser.search_transcripts") as mock_search, \
-         patch("src.synthesiser.research_advertiser", return_value=[]), \
+    with patch("src.synthesiser.research_advertiser", return_value=[]), \
          patch("src.synthesiser.expand_query", return_value={"keywords": ["baking"], "categories": []}), \
          patch("src.synthesiser.recommend_segments", return_value=sample_payload), \
          patch("src.synthesiser.get_campaign_summary", return_value={"summary": "No previous campaign data found for this advertiser.", "campaigns": []}), \
          patch("src.synthesiser.OpenAI") as mock_openai_cls:
 
-        mock_search.return_value = {"documents": [[]], "metadatas": [[]], "distances": [[]]}
         mock_client = MagicMock()
         mock_client.chat.completions.create.return_value = mock_response
         mock_openai_cls.return_value = mock_client


### PR DESCRIPTION
Editorial vector search is deferred to Phase 2. Cut it at its single entry point in the pipeline rather than removing the underlying layer:

- synthesiser.py: comment out the search_transcripts import and replace the ChromaDB search call with `sources = []`, keeping the return contract unchanged for the API/frontend. The vector-DB layer (vectorstore/embeddings/ingest) is left intact and dormant.
- prompts.py: remove the Editorial Insights section and the Editor Voice glance label, repoint Strategic Alignment to audience/trends/research, and drop the {editorial_insights} placeholder so the model can't reference empty editorial data. Client Relationship section preserved.
- test_synthesiser.py: invert the assertions to guard that editorial wiring stays removed; drop the search_transcripts mock.

All 385 backend tests pass.