### PR TITLE
Historical Research Catalogue POC (#125)

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -251,3 +251,34 @@ stops closing prose like `**Combined rationale:**` from being flagged as a fake
 product — the extraction is deliberately coupled to the #93 output format
 (bulleted/numbered list of bold format names). Keep the guardrail and that
 prompt format in sync if either changes.
+
+## 2026-07-21 — Historical Research Catalogue (deterministic relevance gate)
+
+**Word-boundary matching, not bare substring, is the crux of the keyword gate.**
+`src/historical_research.py`'s `get_relevant_research()` decides whether a
+proprietary research file is pulled into a brief by matching each frontmatter
+`topics` + `match_keywords` needle against `topic + advertiser + client_brief`.
+The naive approach — `if needle in brief_text` — silently fires on substrings:
+the keyword `rail` would match `email`, pulling the travel survey into an
+email-marketing brief. Fix: match on a word boundary (`re.search(r"\b" +
+re.escape(needle) + r"\b", brief_text)`). This is what makes "P&O fires, Nike
+doesn't" a reliable, regression-guarded demo. The word-boundary test
+(`email` must NOT match `rail`) is the single most important test in the suite.
+
+**Word boundaries mean plurals need to be listed explicitly.** `\bholiday\b`
+does not match `holidays`. Because the gate is exact-per-word, the curated
+`match_keywords` list carries both singular and plural forms (cruise/cruises,
+holiday/holidays). This is deliberate: the POC prefers a hand-curated,
+demo-proof keyword list over fuzzy stemming (stemming is Phase 2).
+
+**De-dupe `matched_on`.** A term can appear in BOTH `topics` and
+`match_keywords` (e.g. `cruises`), so it matched twice and showed up as a
+duplicate chip on the UI card. `_find_matches` now skips a needle already in
+the hit list.
+
+**Adding a required `{placeholder}` to `USER_PROMPT_TEMPLATE` breaks existing
+render tests.** `str.format()` raises `KeyError` if any `{name}` has no keyword
+arg. Adding `{historical_research}` broke `test_synthesiser.py::test_user_prompt_renders`
+(which calls `.format(...)` with a fixed set of kwargs). Whenever you add a
+placeholder to the template, update every `.format()` call site AND the
+placeholder-presence test in the same commit.

--- a/data/historical_research/travel_audience_research_2024_25.md
+++ b/data/historical_research/travel_audience_research_2024_25.md
@@ -1,0 +1,748 @@
+---
+title: "Immediate Media Travel Audience Research 2024/25"
+document_type: "agent_reference"
+source_type: "proprietary audience survey and audience reach data"
+organisation: "Immediate Media"
+geography: "United Kingdom"
+fieldwork_start: "2024-11-26"
+fieldwork_end: "2024-12-02"
+total_respondents: 1589
+traveller_base: 1430
+primary_use: "Advertising briefs, audience insight, commercial planning and source checking"
+topics:
+  - travel planning
+  - UK holidays
+  - European travel
+  - city breaks
+  - cruises
+  - rail travel
+  - accommodation
+  - travel insurance
+  - travel spending
+  - sustainability
+  - cultural travel
+  - food and dining travel
+  - special-interest holidays
+  - affluent empty-nesters
+match_keywords:
+  - travel
+  - travelling
+  - holiday
+  - holidays
+  - trip
+  - trips
+  - getaway
+  - vacation
+  - staycation
+  - cruise
+  - cruises
+  - cruising
+  - flight
+  - flights
+  - airline
+  - airlines
+  - hotel
+  - hotels
+  - resort
+  - resorts
+  - ferry
+  - rail
+  - tourism
+  - tourist
+  - tour
+  - tours
+  - destination
+  - destinations
+---
+
+# Immediate Media Travel Audience Research 2024/25
+
+## Purpose of this reference
+
+This is a cleaned, retrieval-friendly version of the 53-slide **IM Travel Findings 2024/25** deck. It is designed for an agent assessing whether the research is relevant to an advertising brief and extracting defensible audience evidence.
+
+Use it to answer four questions:
+
+1. Is the research relevant to the advertiser, audience or travel category in the brief?
+2. What measured findings can support the response?
+3. What is a reasonable commercial interpretation of those findings?
+4. What qualifications must accompany the evidence?
+
+This document prioritises total-audience findings. Brand-level differences are included only where they materially affect planning or provide a clear route to an Immediate Media audience.
+
+## When this source is relevant
+
+Consult this source for briefs involving:
+
+- Airlines, rail operators, ferry companies and other travel transport providers
+- Hotels, resorts, bed and breakfasts, holiday rentals and accommodation platforms
+- Tour operators, travel agents, booking platforms and tourism boards
+- UK breaks, European travel, city breaks and short breaks
+- Cruises, particularly ocean, river and adults-only cruises
+- Travel insurance, financial services and premium travel products
+- Food, dining, culinary tourism, local produce and drinks experiences
+- Culture, heritage, museums, gardens, wildlife and nature-based travel
+- Sustainable travel, domestic tourism and lower-carbon transport
+- Affluent older audiences, empty-nesters and solo travellers
+- Special-interest holidays linked to hobbies and passions
+
+## Research metadata
+
+| Item | Detail |
+| --- | --- |
+| Research owner | Immediate Media |
+| Survey | 10-minute survey sent to the UK Insiders Panel |
+| Fieldwork | 26 November to 2 December 2024 |
+| Total completed responses | 1,589 |
+| Main traveller base | 1,430 |
+| Main traveller definition | Respondents other than those who said they definitely would not travel. The original deck uses some inherited 2024 wording even though most questions concern 2025. |
+| Core brand bases | Radio Times n=915 total / 822 travellers; Good Food n=783 / 727; Gardeners' World n=651 / 595 |
+| Reach source | TGI GB November or December 2024, depending on the slide |
+| Geographic scope | UK audience |
+| Original deck | IM Travel Findings 2024/25, 53 slides |
+
+### Source-label warning
+
+The methodology slide says the source for external use is **"Immediate Media Insiders Panel Nov 2023 - Travel and Holidays"**, despite fieldwork being dated November to December 2024. This appears inconsistent. Confirm the approved external source wording with the research owner before using the study publicly.
+
+## Executive evidence summary
+
+- **Travel propensity is high:** 35% had already booked a 2025 holiday or short break, 30% said they would definitely book another and 25% hoped to book. These response options may overlap because respondents could already have booked and still plan another trip.
+- **The audience is broadly stable or growing in travel activity:** 17% expected to take more trips than in 2024, compared with 10% expecting fewer; 52% expected the same amount.
+- **The UK and Europe dominate intended destinations:** 77% selected the UK and 57% selected Europe. France and Spain led European consideration at 32% each, followed by Italy at 27%.
+- **The audience expects multiple trips:** the deck reports averages of 1.7 holidays and 1.9 short breaks in the UK, plus 1.7 holidays and 1.5 short breaks abroad.
+- **Spending intent is commercially strong:** expected average spend on holidays and short breaks was £2,716, around £300 or 12% above the cited UK average of £2,417. Twenty-three per cent selected £4,000 or more.
+- **City breaks lead holiday-type interest:** 61% were interested in city breaks, followed by rail journeys at 33%, walking or active holidays at 29%, beach holidays at 29% and cruises at 23%.
+- **Experience and exploration matter:** 55% said new experiences were important. Relaxation, natural attractions, museums and monuments, nature and wildlife, eating well and local cuisine were prominent desired experiences.
+- **Special-interest travel is a major opportunity:** 73% would consider a holiday based around a passion. History and heritage led at 38%, followed by wildlife and nature at 30% and arts and culture at 27%.
+- **Hotels remain the default accommodation:** 75% would consider hotels, 48% rentals and 45% bed and breakfasts.
+- **Booking behaviour is still conventional:** 63% would book directly with a provider, 42% would use a general booking website and 30% would use a travel agent. Only 1% selected social media as a booking route.
+- **Sustainability is strongest when framed practically:** 82% valued supporting local businesses, 45% would holiday in the UK to reduce their travel carbon footprint, 42% were increasingly likely to use transport other than flying and 38% could choose a travel company for its environmental record.
+- **Cruise interest is concentrated but valuable:** 23% were likely to consider a cruise. Among 334 cruise intenders, ocean, river and adults-only cruises were the leading formats.
+
+## Evidence by advertising problem
+
+### 1. Reaching people already in the travel market
+
+**Survey findings**
+
+- 35% had already booked a holiday or short break for 2025.
+- 30% said they would definitely book another holiday or short break.
+- 25% hoped to book another.
+- 10% said they definitely would not take a holiday or short break.
+- 17% expected more trips than in 2024, 52% expected the same amount and 10% expected fewer.
+
+**Commercial interpretation**
+
+The audience includes both confirmed bookers and people still open to influence. It can support campaigns across inspiration, consideration, booking and add-on purchases rather than only last-minute conversion.
+
+**Relevant advertisers**
+
+Airlines, hotels, holiday operators, tourism boards, booking platforms, travel insurance, payment products, luggage and travel accessories.
+
+**Evidence base**
+
+Total respondents, n=1,589. Original deck slides 6 to 7.
+
+### 2. UK, European and international destination planning
+
+**Survey findings**
+
+| Intended destination | Respondents |
+| --- | ---: |
+| UK | 77% |
+| Europe | 57% |
+| Americas | 10% |
+| Asia | 6% |
+| Africa | 4% |
+| Australia | 4% |
+| Undecided | 4% |
+
+Among those considering Europe, the leading destinations were:
+
+| European destination | Respondents considering Europe |
+| --- | ---: |
+| France | 32% |
+| Spain | 32% |
+| Italy | 27% |
+| Portugal or Madeira | 18% |
+| Greece | 17% |
+| Germany | 16% |
+| Scandinavia or Nordic countries | 13% |
+| Ireland | 10% |
+| Netherlands | 10% |
+
+**Commercial interpretation**
+
+The source is particularly useful for domestic tourism, mainstream European destination marketing and travel brands selling accessible cultural or food-led trips. Long-haul interest exists but is much smaller in this survey.
+
+**ETIAS finding, dated context**
+
+At fieldwork, 51% expected ETIAS to have no impact on European travel frequency, 13% expected to visit less often, 1% said it had already affected them and 24% did not know. ETIAS timing and requirements have changed since the survey, so use this only as a historical measure of audience concern, not as current travel guidance.
+
+**Evidence base**
+
+Traveller base, n=1,430; Europe subset, n=816. Original deck slides 9 to 14.
+
+### 3. Trip frequency and short-break opportunity
+
+**Survey findings**
+
+- 62% expected to take at least one UK holiday of five nights or more.
+- 58% expected to take at least one holiday abroad.
+- 69% expected to take at least one UK short break of up to four nights.
+- 25% expected to take at least one short break abroad.
+
+The deck reports the following average numbers of trips:
+
+| Location | Holidays | Short breaks |
+| --- | ---: | ---: |
+| UK | 1.7 | 1.9 |
+| Abroad | 1.7 | 1.5 |
+
+**Commercial interpretation**
+
+UK short breaks are the broadest frequency opportunity. Overseas trips appear more weighted toward longer holidays than short breaks. This supports year-round planning around weekend breaks, domestic experiences and repeat travel occasions.
+
+**Reliability note**
+
+The average-trip slide is titled "expected to take in 2024", but the surrounding survey questions concern 2025. Treat the figures as belonging to the 2024/25 study and verify the intended year before external use.
+
+**Evidence base**
+
+Traveller base, n=1,430. Original deck slides 15 to 19.
+
+### 4. Travel companions and solo-travel potential
+
+**Survey findings**
+
+| Likely travel companion | Respondents |
+| --- | ---: |
+| Spouse or partner | 68% |
+| Friends | 25% |
+| By themselves | 22% |
+| Children | 22% |
+| Other family members | 14% |
+| Grandchildren | 9% |
+| Parents | 6% |
+| Pets | 6% |
+
+**Commercial interpretation**
+
+Couples remain the core audience, but the 22% travelling alone suggests a credible secondary opportunity for solo-friendly products, escorted tours and flexible room or pricing propositions. This is an inference from companion choice, not a direct measure of demand for a named solo-travel product.
+
+**Evidence base**
+
+Traveller base, n=1,430. Original deck slide 8.
+
+### 5. Booking routes, flexibility and personalisation
+
+**Survey findings**
+
+| Booking route considered | Respondents |
+| --- | ---: |
+| Direct with airline, hotel, villa or other provider | 63% |
+| General booking website | 42% |
+| Travel agent | 30% |
+| Home-sharing or owner-listing site | 22% |
+| Social media channel | 1% |
+
+Planning preferences included:
+
+- 54% wanted dates to be adaptable if extreme weather could affect the trip.
+- 48% wanted to customise a package holiday.
+- 47% wanted notification of the most affordable time to travel.
+- 33% wanted to book tailor-made packages online.
+
+**Commercial interpretation**
+
+Direct response, comparison, flexible booking and tailored-package messages are well aligned to this audience. Price alerts and weather-related flexibility are stronger propositions than abstract claims about personalisation.
+
+**AI caveat**
+
+The deck states that 0% selected consideration of an AI agent as a booking route in late 2024. The exact option and full response set are not reproduced in the chart, and attitudes may have changed quickly. Do not use this as a timeless statement that the audience rejects AI-assisted travel planning.
+
+**Evidence base**
+
+Traveller base, n=1,430. Original deck slides 21, 27 and 43.
+
+### 6. Accommodation opportunity
+
+**Survey findings**
+
+| Accommodation considered | Respondents |
+| --- | ---: |
+| Hotel | 75% |
+| Rental, including Airbnb | 48% |
+| Bed and breakfast | 45% |
+| Family or friend home | 29% |
+| Cruise ship | 21% |
+| Caravan | 14% |
+| Campsite | 10% |
+| Own holiday home | 5% |
+
+**Commercial interpretation**
+
+Hotels have the widest relevance, but rentals and bed and breakfasts are also mainstream. Independent and locally rooted accommodation can connect with the audience's interest in supporting local businesses and authentic experiences.
+
+**Evidence base**
+
+Traveller base, n=1,430. Original deck slide 22.
+
+### 7. Travel spending and premium potential
+
+**Survey findings**
+
+- Average expected spend on holidays and short breaks in the next 12 months: **£2,716**.
+- Cited UK average for the past 12 months: **£2,417**.
+- Reported difference: **+12%**, or roughly £300.
+- 23% selected a total expected spend of £4,000 or more.
+- 24% expected to spend more on UK holidays than in 2024, while 7% expected to spend less.
+- 25% expected to spend more abroad, while 9% expected to spend less.
+- 29% had not decided their total budget and 4% preferred not to say.
+
+**Premium and upgrade signals**
+
+- 34% liked to upgrade elements of a holiday where possible.
+- 21% said the opportunity to experience luxury could contribute to travelling more.
+- 14% were saving for a more luxurious trip than previously.
+- 11% would be interested in paying more for in-room spa or wellness facilities.
+
+**Commercial interpretation**
+
+The audience should not be framed only as bargain seeking. There is meaningful premium potential, but it sits alongside strong interest in affordability notifications and flexible value. Premium campaigns should emphasise a tangible experience, upgrade or convenience rather than status alone.
+
+**Evidence base**
+
+Traveller base, n=1,430. UK comparison from TGI December 2024. Original deck slides 23 to 25 and 43 to 44.
+
+### 8. Travel insurance and reassurance
+
+**Survey findings among respondents considering insurance**
+
+| Policy feature or type | Respondents |
+| --- | ---: |
+| Single-trip insurance | 30% |
+| Annual multi-trip insurance | 30% |
+| Cover for pre-existing medical conditions | 14% |
+| No upper age limit | 8% |
+| General medical insurance | 6% |
+| Baggage insurance | 6% |
+| Trip-delay insurance | 5% |
+| Flight insurance | 4% |
+| Cruise insurance | 4% |
+| Rental-car cover | 3% |
+
+The deck also states that 17% did not plan to take out travel insurance. A bank or building society was the most mentioned source at 17%, and Staysure was the most mentioned named provider at 11%.
+
+**Commercial interpretation**
+
+Both single-trip and annual products are relevant. Cover for medical conditions and age-inclusive policies are notable secondary messages for an older, affluent audience. Cruise and rail advertisers may also benefit from reassurance around delays, medical cover and flexible cancellation.
+
+**Evidence base**
+
+Insurance-considerer base, n=1,189. Original deck slide 26.
+
+### 9. Travel inspiration, discovery and search behaviour
+
+**Survey findings**
+
+| Inspiration source | Respondents |
+| --- | ---: |
+| Friends and family recommendations | 49% |
+| Google search | 38% |
+| Travel websites | 36% |
+| Travel reviews | 31% |
+| Travel brochures | 30% |
+| Television | 22% |
+| Travel guides | 21% |
+| Tourism boards | 18% |
+| Newspapers | 17% |
+| Travel supplements | 15% |
+| Travel magazines | 14% |
+| Social media | 9% |
+| Social media influencers | 1% |
+
+Common travel-related searches included:
+
+| Search topic | Respondents |
+| --- | ---: |
+| Last-minute breaks | 27% |
+| Adults-only or child-free breaks | 26% |
+| All-inclusive breaks | 24% |
+| Winter breaks or winter sun | 13% |
+| Personalised holiday creation | 9% |
+| Multi-country breaks | 8% |
+| How to travel sustainably | 7% |
+| Shoulder-season breaks | 6% |
+
+**Commercial interpretation**
+
+The audience uses both interpersonal recommendation and active digital research. Publisher content can contribute during discovery and validation, particularly through practical guides, trusted recommendations, comparison content and destination inspiration. Influencer-led discovery appears weak in this survey.
+
+**Evidence base**
+
+Traveller base, n=1,430. Original deck slides 30 to 31.
+
+### 10. Holiday types and experience-led travel
+
+**Holiday types considered**
+
+| Holiday type | Respondents |
+| --- | ---: |
+| City break | 61% |
+| Rail journey | 33% |
+| Walking or active holiday | 29% |
+| Beach holiday | 29% |
+| Cruise | 23% |
+| Touring or group holiday | 16% |
+| Safari or wildlife holiday | 13% |
+| Wellness or wellbeing holiday | 13% |
+| Spa holiday | 10% |
+| Adventure holiday | 8% |
+| Sporting spectator holiday | 7% |
+| Ecotourism holiday | 6% |
+
+**What respondents looked forward to**
+
+| Desired experience | Respondents |
+| --- | ---: |
+| Relaxing | 69% |
+| Visiting natural attractions | 64% |
+| Visiting museums, monuments and other attractions | 62% |
+| Spending time with loved ones | 54% |
+| Escaping everyday life | 54% |
+| Seeing nature and wildlife | 53% |
+| Eating well | 51% |
+| Discovering new destinations | 48% |
+| Trying local cuisine | 43% |
+| Outdoor activities | 36% |
+| Wellness or mental wellbeing | 30% |
+| Visiting beaches | 29% |
+
+**Commercial interpretation**
+
+The audience leans toward exploration, culture, nature and food rather than a purely beach-led proposition. Beach travel remains relevant, but campaigns can differentiate through attractions, local culture, rail itineraries, gardens, wildlife and dining experiences.
+
+**Evidence base**
+
+Traveller base, n=1,430. Original deck slides 32, 38, 40 and 41.
+
+### 11. Food, drink and local-experience opportunity
+
+**Survey findings**
+
+- 51% looked forward to eating well.
+- 43% looked forward to trying local cuisine.
+- 44% said they looked for high-quality food or dining experiences on holiday.
+- 20% looked forward to sampling local drinks.
+- 81% had eaten in an independent restaurant while travelling in the previous three years.
+- 20% had taken a vineyard or distillery tour; among those who had not, 14% expressed interest in doing so the following year.
+- 15% would consider a cookery or food special-interest holiday, while 8% would consider a drink-led holiday.
+
+**Commercial interpretation**
+
+This is a strong source for culinary tourism, destination dining, local produce, restaurants, drinks experiences and Good Food-led partnerships. Food is not merely an incidental holiday activity for this audience; it is part of destination choice and quality perception.
+
+**Evidence base**
+
+Traveller base, n=1,430, with varying bases for future-activity interest. Original deck slides 38, 39, 41 and 45.
+
+### 12. Culture, heritage, nature and special interests
+
+**Survey findings**
+
+Seventy-three per cent would consider at least one special-interest holiday.
+
+| Special-interest holiday | Respondents |
+| --- | ---: |
+| History or heritage | 38% |
+| Wildlife or nature | 30% |
+| Arts or culture | 27% |
+| Hiking or walking | 21% |
+| Cookery or food | 15% |
+| Gardening | 13% |
+| Crafting | 12% |
+| Environment, conservation or sustainability | 10% |
+| TV and film | 10% |
+| Drink | 8% |
+| Sport | 8% |
+| Motoring | 6% |
+
+**Commercial interpretation**
+
+The research is especially valuable for briefs where the trip is built around an existing passion. Immediate Media's portfolio can provide context beyond a generic travel audience, including history, gardening, food, culture, wildlife, television, sport and motoring.
+
+**Evidence base**
+
+Traveller base, n=1,430. Original deck slide 39.
+
+### 13. Sustainability and responsible travel
+
+**Survey findings**
+
+| Sustainable planning statement | Agree or strongly agree |
+| --- | ---: |
+| Supporting local communities and businesses is important | 82% |
+| Would holiday in the UK to reduce travel carbon footprint | 45% |
+| Increasingly likely to use transport other than flying | 42% |
+| Would visit a new destination to reduce over-tourism | 40% |
+| Would choose a travel company for a better environmental record | 38% |
+| Seeks connections with local people | 35% |
+| Green-first choices are increasingly important | 34% |
+| Looks for providers enabling sustainable choices | 28% |
+| Carbon footprint is important when booking | 24% |
+
+**Commercial interpretation**
+
+Sustainability is most compelling when made concrete: support local businesses, travel domestically, choose rail or other transport, avoid over-tourism and make a clearly better provider choice. Only 24% said carbon footprint itself was important at booking, so broad environmental claims may be less persuasive than practical benefits and visible actions.
+
+**Relevant advertisers**
+
+Domestic tourism, rail and ferry operators, eco-certified accommodation, destination management organisations, responsible tour operators and brands supporting local communities.
+
+**Evidence base**
+
+Traveller base, n=1,430. Original deck slide 29.
+
+### 14. Cruise opportunity
+
+**Survey findings**
+
+- 23% were very or somewhat likely to consider a cruise in 2025.
+- The cruise-intender base was 334.
+
+Leading cruise lines considered among intenders:
+
+| Cruise line | Cruise intenders |
+| --- | ---: |
+| P&O Cruises | 38% |
+| Fred. Olsen | 31% |
+| Norwegian Cruise Line | 25% |
+| Princess | 25% |
+| Cunard | 25% |
+| Celebrity Cruises | 23% |
+| Royal Caribbean | 22% |
+| Marella Cruises | 18% |
+| Ambassador | 17% |
+
+Leading cruise formats among intenders:
+
+| Cruise format | Cruise intenders |
+| --- | ---: |
+| Ocean cruise | 58% |
+| River cruise | 55% |
+| Adults-only cruise | 54% |
+| Luxury cruise | 31% |
+| Mini or weekend cruise | 23% |
+| Expedition cruise | 15% |
+| Themed cruise | 12% |
+| Eco-friendly or sustainable cruise | 12% |
+
+**Commercial interpretation**
+
+Cruise is not universal, but the addressable group is substantial and has clear preferences. River and adults-only propositions are nearly as attractive as ocean cruising among intenders. Culture, food, nature and affluent older-audience contexts are natural supporting environments.
+
+**Evidence base**
+
+Traveller base, n=1,430; cruise intenders, n=334. Original deck slides 33 to 35.
+
+### 15. Rail, local and emerging experience opportunities
+
+**Survey findings**
+
+- 33% were interested in a holiday or break involving a rail journey.
+- 22% had taken a rail-based break in the previous three years.
+- Among respondents who had not done so recently, 23% expressed interest in a rail-based break the following year.
+- 11% had taken a river cruise; among non-participants, 25% expressed future interest.
+- 15% had stayed in eco-friendly accommodation; among non-participants, 16% expressed future interest.
+- 32% had taken part in a nature-based activity.
+- 30% had booked a tour with a local guide.
+
+**Commercial interpretation**
+
+Rail travel and river cruising show useful headroom between past participation and future interest. Local guides, eco-friendly accommodation and nature-based activities support destination campaigns focused on exploration rather than passive relaxation.
+
+**Evidence-base warning**
+
+The future-interest percentages use varying bases because each item was asked only of people who had not recently done that activity. Do not compare them directly as shares of the total traveller audience.
+
+**Evidence base**
+
+Traveller base n=1,430; future-interest survey n=1,425 with option-specific bases. Original deck slides 32 and 45.
+
+## Brand and audience planning guidance
+
+These are the most useful brand distinctions in the deck. Small percentage differences should not be treated as statistically significant unless formal significance testing is available.
+
+### Radio Times
+
+- 34% had already booked and 29% would definitely book another trip.
+- 25% expected to travel alone, compared with 22% overall.
+- TGI hero-brand data positions Radio Times as a route to holiday planners: index 112 and claimed reach of 5.2m.
+- It is also positioned for cruisers: index 122 and claimed reach of 1.9m.
+
+**Best fit:** cruises, cultural travel, escorted tours, destination entertainment, affluent older travellers and solo-friendly products.
+
+### Good Food
+
+- 38% had already booked, versus 35% overall.
+- 33% would definitely book another, versus 30% overall.
+- 61% considered Europe, versus 57% overall.
+- France and Spain each reached 34% among its Europe intenders, with Italy at 31%.
+- TGI hero-brand data positions Good Food for domestic travellers: index 109 and claimed reach of 3.1m.
+
+**Best fit:** culinary tourism, hotels and destinations with strong dining propositions, European breaks, local food experiences and domestic travel.
+
+### Gardeners' World
+
+- 66% expected at least one UK holiday, compared with 62% overall.
+- TGI hero-brand data positions Gardeners' World for affluent empty-nesters: index 145 and claimed reach of 200k.
+- It is also positioned for sustainable travellers: index 140 and claimed reach of 1m.
+
+**Best fit:** UK tourism, gardens, nature, wildlife, walking, sustainable travel, rural accommodation and premium empty-nester travel.
+
+### Top Gear
+
+- TGI hero-brand data positions Top Gear for city breakers: index 125 and claimed reach of 340k.
+
+**Best fit:** motoring holidays, road trips, transport, city breaks and travel products with an automotive angle.
+
+## Immediate Media audience scale and targeting assets
+
+### TGI audience claims from the deck
+
+Use these figures with the stated December 2024 source and verify them in current planning tools before client use.
+
+| Audience | IM Total reach / index | IM Digital reach / index | IM Print reach / index |
+| --- | --- | --- | --- |
+| Planning a holiday or short break | 4m / i108 | 8.7m / i105 | 2.4m / i126 |
+| Cruisers | 1.5m / i112 | 1.1m / i102 | 400k / i165 |
+| Affluent empty-nesters | approximately 1m / i112 | 700k / i105 | 250k / i157 |
+| Sustainable travellers | 4.4m / i115 | 3.5m / i106 | 1.3m / i167 |
+| Domestic travellers | 4.5m / i117 | 3.6m / i110 | 1.2m / i158 |
+| City breakers | 4m / i111 | 3.2m / i104 | 1m / i146 |
+
+**Data-quality warning:** The deck's IM Total affluent empty-nester slide displays 1m, while its speaker notes say 900k. The table above uses "approximately 1m" to preserve that ambiguity. Some total and digital reach values also appear counterintuitive when compared with one another, so validate all reach figures before use.
+
+### Audience Project segments available in January 2025
+
+- Hotels and resorts
+- Vacation rentals
+- International travellers
+- Domestic travellers
+- Long-haul travellers
+- Holiday purchase intenders
+- Regular holiday goers, three or more trips a year
+- Travellers looking forward to relaxation
+- Travellers looking forward to nature
+- Cruise break goers
+- City break goers
+- Sporting and skiing holiday goers
+- Countryside break goers
+- Beach and resort holiday goers
+- Camping and caravan holiday goers
+- Family park goers
+- Culture seekers
+
+### Permutive segments listed in January 2025
+
+| Segment | Stated reach |
+| --- | ---: |
+| Travel - Travel Intenders, open and all time, segment 8134 | 1.59m |
+| Food and Drink - Travel, recency and all time, segment 69805 | 2.18m |
+
+These segment names and reaches are dated. Check current availability, taxonomy and scale with the audience team before recommending them.
+
+## Advertiser-category mapping
+
+| Advertiser or brief type | Most relevant evidence in this source | Potential Immediate Media context |
+| --- | --- | --- |
+| UK tourism board or domestic operator | 77% consider UK; 69% expect a UK short break; 45% would travel in the UK to reduce carbon | Gardeners' World, Good Food, Radio Times, domestic-traveller segments |
+| European destination, airline or operator | 57% consider Europe; France and Spain 32%, Italy 27%; 61% city-break interest | Radio Times, Good Food, city-break and international-traveller segments |
+| Hotel or resort | 75% consider hotels; 58% have stayed in independent hotels; £2,716 average planned spend | Broad portfolio, affluent empty-nesters, travel intenders |
+| Rental or accommodation platform | 48% consider rentals; 22% consider home-sharing or owner-listing sites | Domestic and international traveller segments |
+| Rail operator | 33% interested in rail journeys; 42% increasingly likely to use transport other than flying | Radio Times, Gardeners' World, sustainable-traveller segments |
+| Cruise line | 23% cruise consideration; river, ocean and adults-only are leading formats | Radio Times, cruise-break-goer segments |
+| Travel insurance | Single-trip and annual multi-trip each 30%; medical-condition cover 14% | Radio Times and affluent older audiences |
+| Food or drinks tourism | 51% want to eat well; 43% local cuisine; 44% seek high-quality dining | Good Food and food-and-travel segments |
+| Culture or heritage destination | 38% special-interest history or heritage; 62% attractions; 27% arts or culture | History, Radio Times, culture-seeker segments |
+| Nature, gardens or wildlife | 64% natural attractions; 53% nature and wildlife; 30% wildlife or nature holidays | Gardeners' World and nature-focused segments |
+| Sustainable travel brand | 82% support local businesses; 38% may choose a provider for environmental record | Gardeners' World, sustainable-traveller segments |
+| Premium travel or finance | £2,716 average planned spend; 23% at £4,000+; 34% like upgrades | Affluent empty-nesters and high-value travel intenders |
+| Solo or escorted travel | 22% likely to travel alone; 25% among Radio Times respondents | Radio Times, cultural tours and cruise contexts |
+| Wellness or spa | 30% look forward to wellness; 23% seek relaxation or wellness destinations | Good Food, Gardeners' World and premium travel contexts |
+
+## Claim-use rules for agents
+
+1. **State the year.** Describe these as late-2024 findings about intended 2025 travel, not as current market behaviour.
+2. **Name the audience.** Say "Immediate Media Insiders Panel respondents" or "Immediate Media travellers", not "UK consumers" without qualification.
+3. **Distinguish intention from behaviour.** "Would consider", "expects" and "is interested in" do not mean booked or purchased.
+4. **Preserve bases.** Use n=1,589 for total-sample questions, n=1,430 for most traveller questions, n=816 for European destination questions, n=1,189 for insurance and n=334 for cruise-intender detail.
+5. **Do not add multi-select percentages.** Many questions allowed multiple answers, so results do not sum to 100%.
+6. **Separate evidence from interpretation.** Commercial implications in this reference are reasoned applications, not additional survey findings.
+7. **Treat small brand differences cautiously.** The deck does not provide significance testing.
+8. **Verify reach before activation.** TGI and segment figures are dated December 2024 or January 2025 and contain at least one internal discrepancy.
+9. **Do not use ETIAS information as current guidance.** The regulatory timeline has changed since fieldwork.
+10. **Do not overstate the AI result.** The 0% booking-agent result is a narrow, time-bound survey response, not a general rejection of AI.
+
+## Important limitations
+
+- The sample consists of Immediate Media's UK Insiders Panel and is not presented as a nationally representative UK consumer survey.
+- Most questions measure stated intention, consideration or preference for 2025 rather than observed purchases.
+- The study was conducted from 26 November to 2 December 2024. Travel demand, regulation, prices and technology attitudes may have changed.
+- Many questions were multi-select, so percentages can exceed 100% when combined.
+- Bases vary by question and should be included when quoting a result.
+- Some slide titles and notes retain inconsistent references to 2023, 2024 and 2025.
+- The deck contains a discrepancy for affluent empty-nester total reach: 1m on the slide versus 900k in speaker notes.
+- The source does not include confidence intervals or statistical significance tests for brand differences.
+- Audience segments and claimed reaches may no longer be active or at the same scale.
+
+## Compact data appendix
+
+### Core survey bases
+
+| Group | Total-sample base | Traveller base |
+| --- | ---: | ---: |
+| All respondents | 1,589 | 1,430 |
+| Radio Times | 915 | 822 |
+| Good Food | 783 | 727 |
+| Gardeners' World | 651 | 595 |
+| Olive | 361 | 341 |
+| History | 336 | 313 |
+| Top Gear | 170 | 162 |
+
+### Most expensive trip spend per adult
+
+| Expected spend | Total respondents |
+| --- | ---: |
+| Up to £249 | 5% |
+| £250 to £499 | 8% |
+| £500 to £999 | 17% |
+| £1,000 to £1,499 | 13% |
+| £1,500 to £1,999 | 9% |
+| £2,000 to £2,999 | 9% |
+| £3,000 to £3,999 | 7% |
+| £4,000 or more | 9% |
+
+### Recent activity and stated future interest
+
+Future-interest bases vary by activity and represent people who had not done the activity recently.
+
+| Activity | Done in previous three years | Interested next year among non-participants |
+| --- | ---: | ---: |
+| Ate in an independent restaurant | 81% | 7% |
+| Stayed in an independent hotel | 58% | 15% |
+| Nature-based activity | 32% | 14% |
+| River cruise | 11% | 25% |
+| Sea cruise | 16% | 14% |
+| Rail-based break | 22% | 23% |
+| Vineyard or distillery tour | 20% | 14% |
+| Tour with a local guide | 30% | 12% |
+| Spa or wellness retreat | 13% | 13% |
+| Eco-friendly accommodation | 15% | 16% |
+| Carbon offset for a flight | 7% | 5% |
+
+## Source trace
+
+This reference was derived from the PowerPoint deck **Travel Category Survey 2024/25 - Master Deck**. The original slide-by-slide markdown transcription should be retained separately as the archival version when exact wording, every brand cut or raw chart detail is required.

--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -10,6 +10,9 @@ import CollapsiblePanel from "@/components/CollapsiblePanel";
 import WritingSamplesModal from "@/components/WritingSamplesModal";
 import DraftEmailModal from "@/components/DraftEmailModal";
 import AudienceSegmentsPanel from "@/components/AudienceSegmentsPanel";
+import HistoricalResearchCard, {
+  HistoricalResearch,
+} from "@/components/HistoricalResearchCard";
 import { useAnalytics } from "@/components/AnalyticsProvider";
 import { useAuth } from "@/contexts/AuthContext";
 import { AudienceSegmentsPayload } from "@/lib/audienceSegments";
@@ -44,6 +47,7 @@ interface InsightsResult {
   format_recommendations: string;
   campaign_history: string;
   client_brief_summary: string;
+  historical_research?: HistoricalResearch;
 }
 
 function SkeletonCard() {
@@ -676,7 +680,11 @@ export default function InsightsTool() {
               const detailSections = sections.filter(
                 (s) =>
                   s.title !== "Key Recommendations" &&
-                  s.title !== "At a Glance",
+                  s.title !== "At a Glance" &&
+                  s.title !== "Historical Research",
+              );
+              const historicalSection = sections.find(
+                (s) => s.title === "Historical Research",
               );
               const glanceCards = atAGlance
                 ? parseGlanceCards(atAGlance.content)
@@ -778,6 +786,12 @@ export default function InsightsTool() {
                         </div>
                       </div>
                     )}
+
+                    {/* Historical Research hero card (saved-brief view). */}
+                    <HistoricalResearchCard
+                      data={savedResult.historical_research}
+                      content={historicalSection?.content}
+                    />
 
                     {detailSections.map((section, i) => (
                       <div
@@ -997,7 +1011,11 @@ export default function InsightsTool() {
                   const detailSections = sections.filter(
                     (s) =>
                       s.title !== "Key Recommendations" &&
-                      s.title !== "At a Glance",
+                      s.title !== "At a Glance" &&
+                      s.title !== "Historical Research",
+                  );
+                  const historicalSection = sections.find(
+                    (s) => s.title === "Historical Research",
                   );
                   const glanceCards = atAGlance
                     ? parseGlanceCards(atAGlance.content)
@@ -1051,6 +1069,13 @@ export default function InsightsTool() {
                           </div>
                         </div>
                       )}
+
+                      {/* Historical Research hero card — proprietary research
+                          pull-through. Renders only on a relevant (matched) brief. */}
+                      <HistoricalResearchCard
+                        data={result.historical_research}
+                        content={historicalSection?.content}
+                      />
 
                       {/* Detail section cards */}
                       {detailSections.map((section, i) => (

--- a/frontend/components/HistoricalResearchCard.tsx
+++ b/frontend/components/HistoricalResearchCard.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+
+/**
+ * Historical Research hero card (PRD #125 / slice #127).
+ *
+ * The "panel is the hero" surface for the proprietary-research pull-through.
+ * Composes two things:
+ *   1. Deterministic frontmatter metadata (source title, organisation,
+ *      fieldwork dates, respondent base, "matched on") passed verbatim from the
+ *      backend `historical_research` dict — no hallucination risk.
+ *   2. The model-generated, brief-tailored findings bullets, parsed from the
+ *      `## Historical Research` output section and passed in as `content`.
+ *
+ * Renders ONLY when `data.relevant === true` — mirroring the conditional render
+ * used for campaign_history. On a non-matching brief the backend sends
+ * `{ relevant: false }` and this component returns null (no empty box).
+ */
+export interface HistoricalResearch {
+  relevant: boolean;
+  title?: string;
+  organisation?: string;
+  fieldwork?: string;
+  total_respondents?: number;
+  matched_on?: string[];
+}
+
+const bulletMarkdownComponents = {
+  a: ({ href, children, ...props }: React.ComponentPropsWithoutRef<"a">) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-accent-cyan hover:underline break-words"
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children, ...props }: React.ComponentPropsWithoutRef<"ul">) => (
+    <ul className="list-disc list-inside space-y-2 mb-0" {...props}>
+      {children}
+    </ul>
+  ),
+  p: ({ children, ...props }: React.ComponentPropsWithoutRef<"p">) => (
+    <p className="mb-3 last:mb-0" {...props}>
+      {children}
+    </p>
+  ),
+  strong: ({
+    children,
+    ...props
+  }: React.ComponentPropsWithoutRef<"strong">) => (
+    <strong className="font-bold text-on-surface" {...props}>
+      {children}
+    </strong>
+  ),
+  li: ({ children, ...props }: React.ComponentPropsWithoutRef<"li">) => (
+    <li className="text-on-surface-variant" {...props}>
+      {children}
+    </li>
+  ),
+};
+
+export default function HistoricalResearchCard({
+  data,
+  content,
+}: {
+  data?: HistoricalResearch;
+  content?: string;
+}) {
+  // Conditional render: only ever appears on a relevant (matched) brief.
+  if (!data || !data.relevant) return null;
+
+  return (
+    <div className="bg-surface-container-lowest rounded-2xl p-8 border border-white/5 border-l-4 border-l-accent-cyan hover:border-accent-cyan/20 transition-all duration-500">
+      <div className="flex items-center gap-3 mb-2">
+        <div className="inline-flex p-3 rounded-xl bg-accent-cyan/10 text-accent-cyan">
+          <svg
+            className="w-7 h-7"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+            />
+          </svg>
+        </div>
+        <span className="text-[10px] font-bold tracking-widest text-accent-cyan uppercase">
+          Proprietary Research
+        </span>
+      </div>
+
+      <h2 className="font-headline text-2xl font-bold mb-4">
+        Historical Research
+      </h2>
+
+      {/* Verbatim frontmatter metadata — provenance the salesperson can cite. */}
+      <div className="rounded-xl border border-white/10 bg-surface-container px-4 py-3 mb-5 space-y-1">
+        {data.title && (
+          <p className="text-on-surface text-sm font-semibold">{data.title}</p>
+        )}
+        <div className="flex flex-wrap gap-x-5 gap-y-1 text-on-surface-variant text-xs">
+          {data.organisation && (
+            <span>
+              Source:{" "}
+              <span className="text-on-surface">{data.organisation}</span>
+            </span>
+          )}
+          {data.fieldwork && (
+            <span>
+              Fieldwork:{" "}
+              <span className="text-on-surface">{data.fieldwork}</span>
+            </span>
+          )}
+          {typeof data.total_respondents === "number" && (
+            <span>
+              Respondent base:{" "}
+              <span className="text-on-surface tabular-nums">
+                n={data.total_respondents.toLocaleString("en-GB")}
+              </span>
+            </span>
+          )}
+        </div>
+        {data.matched_on && data.matched_on.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2 pt-1.5">
+            <span className="text-on-surface-variant text-xs">Matched on:</span>
+            {data.matched_on.map((kw) => (
+              <span
+                key={kw}
+                className="rounded-full bg-surface-container-highest text-accent-cyan text-[11px] font-medium px-2.5 py-0.5"
+              >
+                {kw}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Model-generated, brief-tailored findings bullets. */}
+      {content && (
+        <div className="text-on-surface-variant text-sm leading-relaxed break-words-anywhere">
+          <ReactMarkdown components={bulletMarkdownComponents}>
+            {content}
+          </ReactMarkdown>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/historical_research.py
+++ b/src/historical_research.py
@@ -1,0 +1,117 @@
+import glob
+import os
+import re
+
+import yaml
+
+# Proprietary research catalogue. Markdown files with YAML frontmatter live
+# here and are glob-loaded at runtime — dropping a new `.md` in the folder adds
+# it to the catalogue with no code change (mirrors the skills/*.md pattern in
+# src/web_search.py).
+CATALOGUE_DIR = os.path.join(os.path.dirname(__file__), "..", "data", "historical_research")
+
+# On a brief that matches no research file, the prompt placeholder carries this
+# fallback so the model omits the Historical Research section entirely.
+FALLBACK_TEXT = "No historical research matched this brief."
+
+
+def load_catalogue(catalogue_dir=None):
+    # type: (str) -> list
+    """Glob-load every research file in the catalogue.
+
+    Reuses the frontmatter-parsing pattern from ``src.web_search.load_skills``:
+    split the leading YAML frontmatter from the markdown body, parse the
+    frontmatter with ``yaml.safe_load``. Files without valid frontmatter are
+    skipped. A missing/empty folder yields an empty list (graceful absence).
+
+    Each returned dict carries the parsed ``meta`` frontmatter, the verbatim
+    ``body``, and the flattened ``topics`` + ``match_keywords`` used by the gate.
+    """
+    if catalogue_dir is None:
+        catalogue_dir = CATALOGUE_DIR
+
+    files = []
+    for path in sorted(glob.glob(os.path.join(catalogue_dir, "*.md"))):
+        with open(path) as f:
+            raw = f.read()
+
+        # Split YAML frontmatter from the markdown body.
+        match = re.match(r"^---\n(.+?)\n---\n(.+)", raw, re.DOTALL)
+        if not match:
+            continue
+
+        meta = yaml.safe_load(match.group(1)) or {}
+        body = match.group(2).strip()
+
+        topics = meta.get("topics") or []
+        match_keywords = meta.get("match_keywords") or []
+
+        files.append({
+            "meta": meta,
+            "body": body,
+            "topics": list(topics),
+            "match_keywords": list(match_keywords),
+            "file": os.path.basename(path),
+        })
+
+    return files
+
+
+def _find_matches(brief_text, needles):
+    # type: (str, list) -> list
+    """Return the needles that appear in ``brief_text`` on a word boundary.
+
+    Word-boundary matching (not bare substring) keeps the gate honest: the
+    keyword "rail" matches "rail" but not "email", and the phrase "city breaks"
+    matches only when both words appear together. Deterministic — no LLM.
+    """
+    hits = []
+    for needle in needles:
+        needle = (needle or "").strip().lower()
+        if not needle or needle in hits:
+            continue  # de-dupe: a term can sit in both topics and match_keywords
+        pattern = r"\b" + re.escape(needle) + r"\b"
+        if re.search(pattern, brief_text):
+            hits.append(needle)
+    return hits
+
+
+def get_relevant_research(topic, advertiser, client_brief, catalogue_dir=None):
+    # type: (str, str, str, str) -> dict
+    """Deterministic relevance gate over the research catalogue.
+
+    Concatenates ``topic + advertiser + client_brief`` (lowercased) and tests it
+    against each file's flattened ``topics`` + ``match_keywords``. Any single
+    overlap includes the file. No LLM, no network — reproducible every run.
+
+    Always returns a dict with ``relevant`` and ``prompt_text``. On a match it
+    also carries verbatim frontmatter metadata (``title``, ``organisation``,
+    ``fieldwork``, ``total_respondents``, ``matched_on``) for the hero card.
+    """
+    brief_text = " ".join([topic or "", advertiser or "", client_brief or ""]).lower()
+
+    for f in load_catalogue(catalogue_dir):
+        needles = f["topics"] + f["match_keywords"]
+        matched_on = _find_matches(brief_text, needles)
+        if matched_on:
+            meta = f["meta"]
+            start = str(meta.get("fieldwork_start", "") or "")
+            end = str(meta.get("fieldwork_end", "") or "")
+            if start and end:
+                fieldwork = "%s to %s" % (start, end)
+            else:
+                fieldwork = start or end
+            return {
+                "relevant": True,
+                "prompt_text": f["body"],
+                "title": meta.get("title", ""),
+                "organisation": meta.get("organisation", ""),
+                "fieldwork": fieldwork,
+                "total_respondents": meta.get("total_respondents"),
+                "matched_on": matched_on,
+            }
+
+    return {
+        "relevant": False,
+        "prompt_text": FALLBACK_TEXT,
+    }

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -38,6 +38,11 @@ Always scope the wording to **"direct"** campaigns; never over-claim beyond what
 ## Strategic Alignment
 How the advertiser's stated goals, challenges, and recent activity connect to the audience data, market trends, and brand research provided. Identify specific opportunities where the advertiser's strategy aligns with what the data shows.
 
+## Historical Research
+Only include this section when proprietary Historical Research is supplied below — i.e. it is NOT the exact fallback string "No historical research matched this brief.". When it is that fallback, **omit this section entirely**: do not write the heading, and do not write "none found" or any equivalent into the prose.
+
+When research is present, produce 2–3 findings bullets, each tailored specifically to *this* advertiser and brief (e.g. cruise figures for a cruise brand) and grounded strictly in the supplied research — never invented or extrapolated. When quoting any figure, observe this citation discipline: name the source audience (e.g. "Immediate Media travellers", not "UK consumers"), state the fieldwork date, quote the base `n=` alongside any percentage, present figures as stated intention rather than observed behaviour, and never sum multi-select percentages.
+
 ## Audience Segments & Reach
 Recommend the most relevant targetable audience segments for this brief, based on the Audience Segments & Reach data provided. The data is split by platform (AP = modelled first-party audience, broad reach; Permutive = behavioural, recently engaged browsers) — present them as two separate lists, each in its own scale, and state the one-line framing for each so a broad modelled audience is never oversold as precise intent.
 
@@ -124,6 +129,13 @@ The following is the full catalogue of available ad formats with performance ben
 The following is the advertiser's **direct** campaign history with us, resolved deterministically. Use this to build the Client Relationship section and to inform recommendations. Treat its factual status (a direct history summary, or "No direct campaign history") as ground truth.
 
 {campaign_history}
+
+---
+
+### Historical Research
+The following is proprietary Immediate Media research, selected deterministically as relevant to this brief. Use it to build the Historical Research section. If it reads exactly "No historical research matched this brief.", omit the Historical Research section entirely; otherwise ground 2–3 brief-tailored findings in it and cite with the discipline described above.
+
+{historical_research}
 
 ---
 

--- a/src/synthesiser.py
+++ b/src/synthesiser.py
@@ -12,6 +12,7 @@ from src.trends import get_trend_data
 from src.brief import summarise_brief
 from src.formats import load_format_data, load_format_names, validate_format_names
 from src.campaign_history import get_campaign_summary, load_campaign_rows
+from src.historical_research import get_relevant_research
 from src.alias_table import DEFAULT_UNMATCHED_LOG_PATH
 from src.comparables import (
     get_comparables,
@@ -164,6 +165,14 @@ def generate_insights(
     # 7. Summarise client brief if provided
     client_brief_summary = summarise_brief(client_brief)
 
+    # 7b. Deterministic keyword gate over the proprietary research catalogue.
+    #     On a match the whole file body is woven into the prompt; on a no-match
+    #     a fallback string tells the model to omit the section entirely.
+    historical = get_relevant_research(topic, advertiser, client_brief)
+    historical_research_text = historical["prompt_text"]
+    # The return object carries only the card metadata (never the prompt body).
+    historical_research = {k: v for k, v in historical.items() if k != "prompt_text"}
+
     # 8. Assemble prompt
     user_prompt = USER_PROMPT_TEMPLATE.format(
         topic=topic,
@@ -175,6 +184,7 @@ def generate_insights(
         format_recommendations=format_recommendations,
         campaign_history=campaign_history,
         client_brief=client_brief_summary,
+        historical_research=historical_research_text,
     )
 
     # 9. Call GPT-4o
@@ -204,4 +214,5 @@ def generate_insights(
         "format_recommendations": format_recommendations,
         "campaign_history": campaign_history,
         "client_brief_summary": client_brief_summary,
+        "historical_research": historical_research,
     }

--- a/tests/test_historical_research.py
+++ b/tests/test_historical_research.py
@@ -1,0 +1,309 @@
+import os
+
+import pytest
+
+from src.historical_research import get_relevant_research, load_catalogue
+
+# A minimal fixture file that mirrors the real travel catalogue file's shape:
+# YAML frontmatter with `topics` (verbose phrases) + `match_keywords` (single
+# words) and a markdown body carrying a quotable, dated survey figure.
+FIXTURE_FILE = """---
+title: "Immediate Media Travel Audience Research 2024/25"
+organisation: "Immediate Media"
+fieldwork_start: "2024-11-26"
+fieldwork_end: "2024-12-02"
+total_respondents: 1589
+topics:
+  - cruises
+  - city breaks
+  - rail travel
+match_keywords:
+  - travel
+  - holiday
+  - cruise
+  - flight
+  - hotel
+---
+
+# Immediate Media Travel Audience Research 2024/25
+
+Among 334 cruise intenders, P&O Cruises led consideration at 38%.
+"""
+
+
+@pytest.fixture()
+def catalogue_dir(tmp_path):
+    """A one-file historical-research catalogue in a temp directory."""
+    d = tmp_path / "historical_research"
+    d.mkdir()
+    (d / "travel.md").write_text(FIXTURE_FILE)
+    return str(d)
+
+
+def test_gate_matches_cruise_brief(catalogue_dir):
+    result = get_relevant_research(
+        "cruise campaign for over-50s", "P&O Cruises", "",
+        catalogue_dir=catalogue_dir,
+    )
+    assert result["relevant"] is True
+
+
+def test_gate_ignores_non_travel_brief(catalogue_dir):
+    result = get_relevant_research(
+        "running shoes launch", "Nike", "",
+        catalogue_dir=catalogue_dir,
+    )
+    assert result["relevant"] is False
+    # No-match contract: fallback string present, no metadata keys.
+    assert result["prompt_text"] == "No historical research matched this brief."
+    assert "title" not in result
+
+
+def test_gate_is_case_insensitive(catalogue_dir):
+    result = get_relevant_research(
+        "CRUISE CAMPAIGN", "P&O CRUISES", "",
+        catalogue_dir=catalogue_dir,
+    )
+    assert result["relevant"] is True
+
+
+def test_gate_hits_on_match_keyword(catalogue_dir):
+    # "hotel" is a match_keyword but not a topic phrase.
+    result = get_relevant_research(
+        "budget hotel promotion", "Premier Inn", "",
+        catalogue_dir=catalogue_dir,
+    )
+    assert result["relevant"] is True
+    assert "hotel" in result["matched_on"]
+
+
+def test_gate_hits_on_topic_phrase(catalogue_dir):
+    # "city breaks" is a verbose topics phrase, not a single match_keyword.
+    result = get_relevant_research(
+        "city breaks push", "SomeBrand", "",
+        catalogue_dir=catalogue_dir,
+    )
+    assert result["relevant"] is True
+    assert "city breaks" in result["matched_on"]
+
+
+def test_gate_matches_on_client_brief_only(catalogue_dir):
+    # A keyword present ONLY in client_brief still fires (concatenation).
+    result = get_relevant_research(
+        "generic launch", "Acme", "We want to reach cruise intenders this winter",
+        catalogue_dir=catalogue_dir,
+    )
+    assert result["relevant"] is True
+
+
+def test_match_returns_verbatim_frontmatter_metadata(catalogue_dir):
+    result = get_relevant_research(
+        "cruise campaign", "P&O Cruises", "",
+        catalogue_dir=catalogue_dir,
+    )
+    assert result["title"] == "Immediate Media Travel Audience Research 2024/25"
+    assert result["organisation"] == "Immediate Media"
+    assert result["fieldwork"] == "2024-11-26 to 2024-12-02"
+    assert result["total_respondents"] == 1589
+    # The whole file body rides through verbatim for the single GPT-4o call.
+    assert "334 cruise intenders" in result["prompt_text"]
+
+
+# --- Loader ---------------------------------------------------------------
+
+def test_loader_parses_frontmatter_and_body(catalogue_dir):
+    files = load_catalogue(catalogue_dir)
+    assert len(files) == 1
+    f = files[0]
+    assert f["meta"]["title"] == "Immediate Media Travel Audience Research 2024/25"
+    assert "cruise" in f["match_keywords"]
+    assert "cruises" in f["topics"]
+    assert f["body"].startswith("# Immediate Media Travel Audience Research")
+
+
+def test_loader_missing_folder_returns_empty(tmp_path):
+    missing = str(tmp_path / "does_not_exist")
+    assert load_catalogue(missing) == []
+
+
+def test_loader_empty_folder_returns_empty(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert load_catalogue(str(empty)) == []
+
+
+def test_gate_no_files_is_not_relevant(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    result = get_relevant_research("cruise", "P&O", "", catalogue_dir=str(empty))
+    assert result["relevant"] is False
+    assert result["prompt_text"] == "No historical research matched this brief."
+
+
+# --- Real catalogue regression guard (the demo) ---------------------------
+
+def test_real_catalogue_pando_fires_nike_doesnt():
+    """The live-demo regression guard, run against the actual shipped file."""
+    pando = get_relevant_research("cruise campaign for over-50s", "P&O Cruises", "")
+    assert pando["relevant"] is True
+    assert pando["total_respondents"] == 1589
+
+    nike = get_relevant_research("running shoes launch", "Nike", "")
+    assert nike["relevant"] is False
+
+
+# --- Edge-case hardening --------------------------------------------------
+
+# Fixture: a catalogue file whose frontmatter has `topics` but NO `match_keywords`
+# key at all. The loader must still parse it and the gate must still match on topics.
+FIXTURE_NO_MATCH_KEYWORDS = """\
+---
+title: "Outdoor Activities Study 2025"
+organisation: "TestOrg"
+fieldwork_start: "2025-01-01"
+fieldwork_end: "2025-01-31"
+total_respondents: 500
+topics:
+  - hiking
+  - camping
+---
+
+# Outdoor Activities Study 2025
+
+Survey of 500 outdoor enthusiasts.
+"""
+
+# Fixture: a file with no YAML frontmatter delimiter at all — should be skipped.
+FIXTURE_MALFORMED = """\
+This file has no frontmatter.
+
+Just some markdown content that should be ignored by the loader.
+"""
+
+# Fixture: a second catalogue file to test multi-file matching.
+FIXTURE_FILE_B = """\
+---
+title: "Tech Consumer Survey 2025"
+organisation: "TechResearch Ltd"
+fieldwork_start: "2025-03-01"
+fieldwork_end: "2025-03-15"
+total_respondents: 800
+topics:
+  - smartphones
+match_keywords:
+  - mobile
+  - tech
+---
+
+# Tech Consumer Survey 2025
+
+Survey of 800 smartphone users.
+"""
+
+
+@pytest.fixture()
+def catalogue_dir_no_match_keywords(tmp_path):
+    """Catalogue with one file that has topics but no match_keywords key."""
+    d = tmp_path / "historical_research"
+    d.mkdir()
+    (d / "outdoor.md").write_text(FIXTURE_NO_MATCH_KEYWORDS)
+    return str(d)
+
+
+@pytest.fixture()
+def catalogue_dir_with_malformed(tmp_path):
+    """Catalogue with one valid file and one malformed file (no frontmatter)."""
+    d = tmp_path / "historical_research"
+    d.mkdir()
+    (d / "travel.md").write_text(FIXTURE_FILE)
+    (d / "broken.md").write_text(FIXTURE_MALFORMED)
+    return str(d)
+
+
+@pytest.fixture()
+def catalogue_dir_two_files(tmp_path):
+    """Catalogue with two valid files — travel.md (first alphabetically) and tech.md."""
+    d = tmp_path / "historical_research"
+    d.mkdir()
+    # "aaa_tech.md" sorts before "travel.md" so it comes first in sorted glob.
+    (d / "aaa_tech.md").write_text(FIXTURE_FILE_B)
+    (d / "travel.md").write_text(FIXTURE_FILE)
+    return str(d)
+
+
+def test_loader_skips_file_without_match_keywords_key(catalogue_dir_no_match_keywords):
+    """A file with topics but no match_keywords key loads with an empty keyword list."""
+    files = load_catalogue(catalogue_dir_no_match_keywords)
+    assert len(files) == 1
+    assert files[0]["match_keywords"] == []
+    assert "hiking" in files[0]["topics"]
+
+
+def test_gate_matches_on_topics_when_match_keywords_absent(catalogue_dir_no_match_keywords):
+    """Gate still fires on a topic phrase when match_keywords is missing entirely."""
+    result = get_relevant_research("hiking holiday", "OutdoorBrand", "",
+                                   catalogue_dir=catalogue_dir_no_match_keywords)
+    assert result["relevant"] is True
+    assert "hiking" in result["matched_on"]
+
+
+def test_loader_skips_malformed_file_silently(catalogue_dir_with_malformed):
+    """A .md file with no YAML frontmatter block is skipped; the valid file loads."""
+    files = load_catalogue(catalogue_dir_with_malformed)
+    # Only the valid travel.md should be loaded; broken.md must be silently dropped.
+    assert len(files) == 1
+    assert files[0]["meta"]["title"] == "Immediate Media Travel Audience Research 2024/25"
+
+
+def test_gate_word_boundary_rail_does_not_match_email(catalogue_dir):
+    """The keyword 'rail' must NOT fire when the brief only contains 'email'.
+
+    'email' contains 'rail' as a substring but the word-boundary regex must
+    prevent this false positive — otherwise any brief mentioning email marketing
+    would incorrectly trigger the travel research file.
+    """
+    result = get_relevant_research(
+        "email marketing push", "Acme Retail", "Send email newsletter to subscribers",
+        catalogue_dir=catalogue_dir,
+    )
+    # 'rail travel' is a topic phrase — but none of the brief words are 'rail'.
+    # 'email' must NOT count as a hit for the needle 'rail'.
+    assert result["relevant"] is False
+
+
+def test_gate_multi_file_returns_first_alphabetical_match(catalogue_dir_two_files):
+    """When multiple files match, the function returns the first (sorted) match only."""
+    # Both files match on "mobile" (tech.md) and "cruise" (travel.md), but
+    # "mobile" only appears in aaa_tech.md — use a brief that hits only aaa_tech.md.
+    result = get_relevant_research(
+        "mobile phone campaign", "Samsung", "",
+        catalogue_dir=catalogue_dir_two_files,
+    )
+    assert result["relevant"] is True
+    assert result["title"] == "Tech Consumer Survey 2025"
+    assert result["total_respondents"] == 800
+
+
+def test_gate_second_file_matches_when_first_does_not(catalogue_dir_two_files):
+    """A brief that skips the first file still matches the second one."""
+    # "cruise" is only in travel.md (which sorts after aaa_tech.md).
+    result = get_relevant_research(
+        "luxury cruise holiday", "P&O Cruises", "",
+        catalogue_dir=catalogue_dir_two_files,
+    )
+    assert result["relevant"] is True
+    assert result["title"] == "Immediate Media Travel Audience Research 2024/25"
+
+
+def test_gate_empty_string_inputs_do_not_crash(catalogue_dir):
+    """All-empty string inputs return a well-formed no-match result without raising."""
+    result = get_relevant_research("", "", "", catalogue_dir=catalogue_dir)
+    assert result["relevant"] is False
+    assert result["prompt_text"] == "No historical research matched this brief."
+
+
+def test_gate_none_inputs_do_not_crash(catalogue_dir):
+    """None inputs are tolerated without raising — treated as empty strings."""
+    result = get_relevant_research(None, None, None, catalogue_dir=catalogue_dir)
+    assert result["relevant"] is False
+    assert result["prompt_text"] == "No historical research matched this brief."

--- a/tests/test_synthesiser.py
+++ b/tests/test_synthesiser.py
@@ -189,6 +189,7 @@ def test_user_prompt_template_has_placeholders():
     assert "{format_recommendations}" in USER_PROMPT_TEMPLATE
     assert "{campaign_history}" in USER_PROMPT_TEMPLATE
     assert "{client_brief}" in USER_PROMPT_TEMPLATE
+    assert "{historical_research}" in USER_PROMPT_TEMPLATE
 
 
 def test_user_prompt_renders():
@@ -202,6 +203,7 @@ def test_user_prompt_renders():
         format_recommendations="some formats",
         campaign_history="some history",
         client_brief="some brief",
+        historical_research="some historical research",
     )
     assert "test topic" in rendered
     assert "test brand" in rendered


### PR DESCRIPTION
## What this does
Pulls the company's own proprietary research into a brief automatically, only when relevant, and visibly to the salesperson. Starts with one real file (Immediate Media Travel Audience Research 2024/25) and proves the end-to-end path. Closes #126 and #127.

## Slice 1 — backend pull-through (#126)
- `data/historical_research/*.md` catalogue with a curated `match_keywords` frontmatter field
- `src/historical_research.py`: glob loader + **deterministic** relevance gate (word-boundary match of `topics` + `match_keywords` over `topic + advertiser + client_brief`; any single hit includes the file; no LLM in selection)
- `prompts.py`: `{historical_research}` placeholder + `## Historical Research` output section (omitted on the no-match fallback) + one claim-use discipline sentence
- `synthesiser.py`: call the gate, inject the file body on match, always return a `historical_research` dict carrying a `relevant` boolean

## Slice 2 — hero card (#127)
- `HistoricalResearchCard.tsx`: verbatim frontmatter metadata (source, fieldwork, `n=` base, matched-on chips) + model bullets; renders only when `relevant === true`
- `/app` page: card wired into live and saved-brief views; section excluded from the generic renderer

## Verification
- 405 backend + 39 frontend tests pass; `tsc --noEmit` clean
- Live GPT-4o dry-run: **P&O Cruises** → section cites the survey (n=334 cruise intenders); **Nike** → section omitted, no card
- The word-boundary gate is the regression guard for the demo (`email` must not match keyword `rail`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)