### PR TITLE
Anchor advertiser research to the brief's topic (#155)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,9 @@ python3 ingest.py
 ## Environment
 
 ### Backend
+
 Requires a `.env` file at root with:
+
 - `OPENAI_API_KEY` (required)
 - `JWT_SECRET` (required — no default, app will not start without it)
 - `DATABASE_URL` (defaults to `sqlite:///users.db` for local dev)
@@ -45,7 +47,9 @@ Optional Chroma Cloud: `CHROMA_CLOUD_API_KEY`, `CHROMA_CLOUD_TENANT`, `CHROMA_CL
 Python 3.11 for production (Railway via `runtime.txt`). Local macOS system Python 3.9 also works — do not use `dict | None` union syntax or other 3.10+ features.
 
 ### Frontend
+
 Requires `frontend/.env.local` with:
+
 - `NEXT_PUBLIC_MIXPANEL_TOKEN` — Mixpanel project token (EU data residency)
 
 ## Architecture
@@ -55,6 +59,7 @@ Prism Data Vault is a RAG-based advertising strategy insights tool. The frontend
 ### Backend (FastAPI + Python `src/`)
 
 **API endpoints** (`api/main.py`):
+
 - `POST /api/auth/signup` — register (email, name, password) → JWT cookie
 - `POST /api/auth/login` — authenticate → JWT cookie
 - `POST /api/auth/logout` — clear cookie
@@ -64,16 +69,19 @@ Prism Data Vault is a RAG-based advertising strategy insights tool. The frontend
 - `POST /api/leaderboard` — submit Tetris score
 
 **Auth** (`api/auth.py`):
+
 - JWT tokens (7-day expiry) stored as httponly `access_token` cookie (samesite=lax)
 - Password hashing via bcrypt (passlib)
 - `get_current_user()` dependency extracts/verifies JWT from cookie
 
 **Database** (`api/database.py`):
+
 - SQLite via aiosqlite
 - Users table: `id, email, name, hashed_password, created_at`
 - DB file: `users.db` at project root
 
 **Data sources** (gathered in `src/synthesiser.py`):
+
 1. **Editorial transcripts** — JSON files in `data/transcripts/`, embedded into ChromaDB (`src/embeddings.py`, `src/vectorstore.py`)
 2. **Advertiser web research** — skill-based DuckDuckGo + GPT-4o (`src/web_search.py`)
 3. **Audience data** — CSV trends in `data/audience_trends.csv` (`src/audience.py`)
@@ -89,6 +97,7 @@ Prism Data Vault is a RAG-based advertising strategy insights tool. The frontend
 **Important**: This project uses Next.js 16.2.1 with Turbopack. Middleware uses the `proxy.ts` convention (not `middleware.ts`). Read `node_modules/next/dist/docs/` before making framework-level changes.
 
 **Pages**:
+
 - `/` — marketing landing page (Prism Deep Sea design system)
 - `/app` — insights tool (protected route)
 - `/login` — login form
@@ -96,40 +105,49 @@ Prism Data Vault is a RAG-based advertising strategy insights tool. The frontend
 - `/tetris` — Tetris game with leaderboard
 
 **Route protection** (dual approach):
+
 1. **Server-side**: `proxy.ts` checks for `access_token` cookie on `/app/*` routes, redirects to `/login?redirect=...` if missing
 2. **Client-side**: `useAuth()` guard in `/app/page.tsx` handles client-side navigation that bypasses the proxy
 
 **Auth context** (`contexts/AuthContext.tsx`):
+
 - `AuthProvider` wraps entire app (via `providers.tsx` → `layout.tsx`)
 - `useAuth()` hook: `{ user, loading, login, signup, logout }`
 - Login/signup pages must use `useAuth()` methods (not raw fetch) so state updates before navigation
 - Calls `mixpanel.identify()` on successful auth
 
 **Analytics** (`components/AnalyticsProvider.tsx`):
+
 - Mixpanel with EU API host (`api-eu.mixpanel.com`)
 - Auto page-view tracking via `usePathname()`
 - `useAnalytics()` hook: `{ track, identify }`
 
 **Design system** (Prism Deep Sea):
+
 - Tokens in `app/globals.css` using Tailwind v4 `@theme`
 - Dark mode: ultra-dark surfaces (#0a0c10) + cyan accent (#1F89DF)
 - Glass-card effect, refractive gradients, glow effects
 - Fonts: Montserrat (headlines), Inter (body)
 
 **Components** (`components/`):
+
 - Navbar, Footer, GlassCard, Button, CollapsiblePanel, SectionHeading, StatusDot
 - Tetris: TetrisBoard, tetris-engine, useTetris, Leaderboard, PiecePreview
 
 ### Research skills system
 
-`skills/*.md` files define extensible research capabilities. Each has YAML frontmatter (`name`, `queries` with `{brand}` placeholder, `max_results_per_query`) and a prompt body with `{brand}` and `{search_results}` placeholders. `src/web_search.py` loads all skills at runtime via glob — adding a new `.md` file adds a new research dimension with no code changes.
+`skills/*.md` files define extensible research capabilities. Each has YAML frontmatter (`name`, `queries` with `{brand}` placeholder, `topic_queries` with `{brand}` and `{topic}`, `max_results_per_query`) and a prompt body with `{brand}`, `{topic}` and `{search_results}` placeholders. `src/web_search.py` loads all skills at runtime via glob — adding a new `.md` file adds a new research dimension with no code changes.
+
+Research is anchored to the brief's topic. `queries` always run (brand-only baseline); `topic_queries` run only when the brief supplies a topic, and any template mentioning `{topic}` is dropped rather than substituted blank when it does not. Results are tagged with `topic_anchored` and rendered to the prompt in two labelled sections — topic-specific vs general brand — so a thin topic section reads as an absence.
+
+`web_search._build_topic_directive()` appends a topic instruction to every skill prompt when a topic is present, so no skill can opt out of the rule that general brand material must not be presented as topic material. Frontmatter `topic_focus` chooses how hard the topic reshapes that skill: `lead` (the default) puts topic material first; `supplement` keeps the skill's general picture whole and adds a topic passage. Company Overview is `supplement` because it feeds the brief's Advertiser Overview section, which needs brand-general facts whatever the brief asks about. The client brief reaches the summariser as context only; it is never turned into a search query.
 
 DuckDuckGo searches use the `ddgs` package (not the deprecated `duckduckgo_search`). Rate limiting (1.5s between queries) and retries (3 attempts, 2s delay) handle transient TLS failures.
 
 ### Key data contracts
 
 - `generate_insights()` returns: `{content, sources, research_skills, audience_timing, google_trends, format_recommendations, client_brief_summary}`
-- Each skill result: `{skill_name, raw_results, processed_summary, error}`
+- Each skill result: `{skill_name, raw_results, processed_summary, error}`; each entry in `raw_results` is `{title, body, href, topic_anchored}`, where `topic_anchored` records whether that hit came from a topic query or a brand-only one
 - `USER_PROMPT_TEMPLATE` placeholders: `{topic}`, `{advertiser}`, `{advertiser_kpi}`, `{editorial_insights}`, `{advertiser_research}`, `{audience_timing}`, `{google_trends}`, `{format_recommendations}`, `{client_brief}`
 
 ### Prompt structure

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -365,7 +365,7 @@ usage-analytics wayfinder map, each told to commit findings to its own throwaway
 branch (`research/databricks-batch-write`, `research/openai-cost-accounting`).
 They ran in the **same working directory**. The second agent created and checked
 out its branch while the first was mid-task, so the first agent's commit landed on
-the *wrong* branch. It "fixed" this by force-moving the other agent's branch
+the _wrong_ branch. It "fixed" this by force-moving the other agent's branch
 (`git branch -f research/openai-cost-accounting 30f49e2`) — destructive, unprompted,
 and on a branch it did not own.
 
@@ -386,6 +386,7 @@ The second agent had not yet committed. Recovery was luck, not design — the sa
 sequence a few minutes later would have discarded real work.
 
 **Checks worth running after any concurrent-agent git incident:**
+
 - `git reflog show <branch>` — the authoritative history of where a ref pointed.
   Survives force-moves and is the fastest way to prove whether work was lost.
 - `git merge-base --is-ancestor <commit> main` — confirms stray commits did not
@@ -400,3 +401,55 @@ concurrent `checkout`/`commit`.
 **Also:** subagents will take destructive git actions to recover from a confusing
 state. Prompts for agents with write access should say explicitly: never
 force-move, reset, or delete a branch you did not create.
+
+---
+
+## 2026-08-05 — A prompt cannot stay on a topic it was never given (#155)
+
+**What went wrong:** QA reported the advertiser research "drifting" off topic — a
+Morrisons Christmas brief returned pages about their kidswear brand, a Patagonia
+gut-health brief returned outdoor and sustainability. The natural reading is
+model drift, and the natural fix is a sterner prompt.
+
+**Why:** neither. `research_advertiser()` took only `brand_name`. The topic and
+client brief never reached the search step, so every query was brand-only and
+the model was faithfully summarising what it had been handed: general brand
+material. No prompt wording could have rescued it — the topic-specific pages
+were never fetched.
+
+**How it was fixed:** three seams, not one.
+
+1. `topic_queries` in skill frontmatter — searches that actually mention the
+   topic. Any template containing `{topic}` is _dropped_ when there is no topic,
+   never substituted blank; a blank substitution silently collapses the query
+   back to brand-only, which is the original bug wearing a disguise.
+2. Results carry `topic_anchored` provenance and render into two labelled
+   sections. An empty topic section prints "(none — …)" rather than vanishing,
+   so absence is visible to the model instead of being inferred from silence.
+3. The topic directive is appended by `web_search.py`, not written into each
+   `skills/*.md`. Skills stay drop-in extensible _and_ no skill — including one
+   added later by someone who never read this — can opt out of the instruction
+   that stops general brand material being passed off as topic material.
+4. `topic_focus` per skill. The first version applied one directive to every
+   skill: "use general brand material only where it bears on the topic." That
+   would have thinned the brief's Advertiser Overview section, which needs
+   scale, positioning and group structure _whatever_ the brief asks about —
+   fixing the reported bug by causing a quieter one. Company Overview is now
+   `supplement` (keep the general picture, add a topic passage); the rest are
+   `lead`.
+
+**The test that proved nothing.** `test_run_skill_without_topic_is_unchanged`
+was written as the evidence for "thick-roster briefs are no worse than today".
+It isn't: `topic` is a required field on `InsightsRequest`, so the no-topic path
+is unreachable in production and every real brief takes the topic path. A test
+covering a path users cannot reach is not regression cover, however green it is.
+Check reachability before citing a test as evidence for an acceptance criterion.
+
+**Transferable lesson:** when output is off-topic, check what reached the prompt
+before rewriting the prompt. "The model ignored the topic" and "the model was
+never told the topic" produce identical symptoms and have completely different
+fixes. Trace the parameter, then judge the wording.
+
+**Cost, recorded honestly:** searches per brief go from 9 to 15 when a topic is
+present, roughly +9s of rate-limit delay. That was accepted as the price of the
+fix, not overlooked.

--- a/frontend/app/app/page.tsx
+++ b/frontend/app/app/page.tsx
@@ -29,6 +29,9 @@ interface RawResult {
   href?: string;
   title?: string;
   body: string;
+  /** True when this hit came from a topic-anchored search rather than a
+   *  brand-only one. Optional so an older cached brief still parses. */
+  topic_anchored?: boolean;
 }
 
 interface SkillResult {

--- a/skills/company_overview.md
+++ b/skills/company_overview.md
@@ -5,11 +5,19 @@ queries:
   - '"{brand}" about company overview'
   - '"{brand}" who are what do they do'
   - '"{brand}" products services customers market'
+topic_queries:
+  - '"{brand}" {topic}'
+  - '"{brand}" {topic} range offering'
+# This skill feeds the brief's Advertiser Overview section, which needs the
+# general picture whatever the topic is. The topic adds a passage here; it
+# does not displace the overview.
+topic_focus: supplement
 max_results_per_query: 3
 timelimit: null
 ---
 
 Analyse the following search results about {brand} and produce a detailed factual overview:
+
 - What the company does and their core products/services
 - Market position, scale, and key metrics (revenue, store count, market share, etc.)
 - Target customers and demographics

--- a/skills/recent_news.md
+++ b/skills/recent_news.md
@@ -5,11 +5,15 @@ queries:
   - '"{brand}" news announcements latest'
   - '"{brand}" campaign launch partnership'
   - '"{brand}" advertising sponsorship {year}'
+topic_queries:
+  - '"{brand}" {topic} news {year}'
+  - '"{brand}" {topic} campaign launch'
 max_results_per_query: 3
 timelimit: "y"
 ---
 
 Summarise the following search results about {brand} into a detailed digest of recent activity:
+
 - New campaigns or marketing initiatives (include campaign names and themes)
 - Product launches or updates
 - Partnerships, sponsorships, or collaborations

--- a/skills/strategy_and_challenges.md
+++ b/skills/strategy_and_challenges.md
@@ -5,11 +5,15 @@ queries:
   - '"{brand}" strategy goals priorities {year}'
   - '"{brand}" challenges opportunities'
   - '"{brand}" marketing strategy advertising focus'
+topic_queries:
+  - '"{brand}" {topic} strategy plans'
+  - '"{brand}" {topic} growth opportunity'
 max_results_per_query: 3
 timelimit: "y"
 ---
 
 Analyse the following search results about {brand} and identify:
+
 - Stated strategic goals or priorities (with timeframes if available)
 - Key challenges or headwinds the company faces
 - Growth areas or opportunities being pursued

--- a/src/synthesiser.py
+++ b/src/synthesiser.py
@@ -135,8 +135,18 @@ def generate_insights(
     #    empty list so the return contract is unchanged for the API/frontend.
     sources = []
 
-    # 2. Skill-based advertiser research
-    skill_results = research_advertiser(advertiser)
+    # 2. Summarise the client brief. This runs up front rather than at step 7
+    #    because the advertiser research reads it as context, so it has to
+    #    exist before step 2b. Still one call — the summary is reused below.
+    client_brief_summary = summarise_brief(client_brief)
+    # summarise_brief() returns a "no brief" sentinel for empty input; research
+    # wants an empty string in that case, not a sentence about the absence.
+    brief_context = client_brief_summary if (client_brief or "").strip() else ""
+
+    # 2b. Skill-based advertiser research, anchored to the brief's topic. Without
+    #     the topic the searches run on the advertiser name alone and come back
+    #     describing whatever the brand is best known for (#155).
+    skill_results = research_advertiser(advertiser, topic=topic, client_brief=brief_context)
     advertiser_research = _format_advertiser_research(skill_results)
 
     # 3. Recommend audience segments (LLM term-expansion + deterministic filter).
@@ -171,8 +181,7 @@ def generate_insights(
         if comparables_block:
             campaign_history = campaign_history + "\n\n" + comparables_block
 
-    # 7. Summarise client brief if provided
-    client_brief_summary = summarise_brief(client_brief)
+    # 7. (Client brief summarised at step 2 — the research step needs it first.)
 
     # 7b. Deterministic keyword gate over the proprietary research catalogue.
     #     On a match the whole file body is woven into the prompt; on a no-match

--- a/src/web_search.py
+++ b/src/web_search.py
@@ -16,6 +16,72 @@ SEARCH_DELAY = 1.5  # seconds between successive queries to avoid rate limits
 
 SKILLS_DIR = os.path.join(os.path.dirname(__file__), "..", "skills")
 
+# The client brief reaches the summariser as context, not as a search term.
+# It arrives already summarised, so this is a backstop against an outlier.
+MAX_BRIEF_CHARS = 800
+
+TOPIC_SECTION_HEADER = 'TOPIC-SPECIFIC RESULTS — {brand} in relation to "{topic}":'
+GENERAL_SECTION_HEADER = 'GENERAL BRAND RESULTS — {brand} only, not specific to "{topic}":'
+NO_TOPIC_RESULTS = '(none — searches for {brand} and "{topic}" returned nothing)'
+
+# How a skill should let the topic reshape its summary. `lead` puts topic
+# material first; `supplement` keeps the skill's general picture whole and adds
+# a topic passage to it. Company Overview is `supplement` because it feeds the
+# brief's Advertiser Overview section, which needs brand-general facts (scale,
+# positioning, group structure) whatever the brief is about — demoting those
+# would make thick-roster briefs worse, not better (#155 AC4).
+TOPIC_FOCUS_LEAD = "lead"
+TOPIC_FOCUS_SUPPLEMENT = "supplement"
+
+# Appended to every skill prompt when the brief carries a topic. Composed here
+# rather than written into each skills/*.md so that adding a new skill file
+# still needs no code change — and so no skill can quietly opt out of the
+# instruction that stops general brand material being passed off as topic
+# material (#155).
+_DIRECTIVE_HEADER = """
+
+---
+
+## Brief context
+
+This research supports an advertising brief for {brand} on the subject of: **{topic}**.{brief_line}
+
+The search results above are split into two sections. Treat them differently:
+"""
+
+_LEAD_RULES = """
+- Lead with the TOPIC-SPECIFIC results. What they say about {brand} in relation to {topic} is the point of this summary.
+- Draw on the GENERAL BRAND RESULTS only as supporting context, and only where it bears on {topic}."""
+
+_SUPPLEMENT_RULES = """
+- Keep the general picture of {brand} complete — what they do, scale, market position, customers, positioning, group structure. A brief needs that context whatever its subject, so do not drop it.
+- Then add, as its own passage, what the TOPIC-SPECIFIC results say about {brand} in relation to {topic}."""
+
+_SHARED_RULES = """
+- If the TOPIC-SPECIFIC section is empty or thin, say so plainly in a sentence — for example "Little material found on {brand} in relation to {topic}." Do not pad the summary with general brand material presented as though it answered the topic.
+- Never imply that general brand material is about {topic}."""
+
+BRIEF_CONTEXT_LINE = "\n\nThe client's brief: {client_brief}"
+
+
+def _build_topic_directive(brand_name, topic, client_brief, topic_focus):
+    # type: (str, str, str, str) -> str
+    """Compose the topic instruction appended to a skill's prompt.
+
+    `topic_focus` selects how hard the topic reshapes the summary; the rule
+    against dressing general brand material up as topic material is shared by
+    both, so no skill can opt out of it.
+    """
+    brief = (client_brief or "").strip()[:MAX_BRIEF_CHARS]
+    rules = (
+        _SUPPLEMENT_RULES if topic_focus == TOPIC_FOCUS_SUPPLEMENT else _LEAD_RULES
+    )
+    return (_DIRECTIVE_HEADER + rules + _SHARED_RULES).format(
+        brand=brand_name,
+        topic=topic,
+        brief_line=BRIEF_CONTEXT_LINE.format(client_brief=brief) if brief else "",
+    )
+
 
 def load_skills() -> list[dict]:
     """Load all research skill definitions from skills/*.md files.
@@ -40,6 +106,9 @@ def load_skills() -> list[dict]:
             "name": meta.get("name", os.path.basename(path)),
             "description": meta.get("description", ""),
             "queries": meta.get("queries", []),
+            # Topic-anchored searches, run only when the brief supplies a topic.
+            "topic_queries": meta.get("topic_queries", []),
+            "topic_focus": meta.get("topic_focus", TOPIC_FOCUS_LEAD),
             "max_results_per_query": meta.get("max_results_per_query", 3),
             "timelimit": meta.get("timelimit", "y"),
             "prompt": prompt_body,
@@ -63,26 +132,119 @@ def _run_search(query, max_results, timelimit="y"):
     return []
 
 
-def run_skill(skill: dict, brand_name: str) -> dict:
-    """Execute a single research skill against a brand.
+def _normalise_topic(topic) -> str:
+    """The brief's topic as a clean string; absent and blank both become ''."""
+    return (topic or "").strip()
 
-    Runs the skill's search queries, then passes the raw results through
-    GPT-4o with the skill's prompt to produce a processed summary.
+
+def _skill_queries(skill: dict, topic) -> list:
+    """Return [(query_template, topic_anchored)] for this run.
+
+    A template is topic-anchored if it mentions {topic}. With no topic in the
+    brief those templates are dropped rather than substituted blank — an empty
+    substitution would silently widen the search back into a brand-only one.
+    """
+    templates = list(skill.get("queries") or []) + list(skill.get("topic_queries") or [])
+    has_topic = bool(_normalise_topic(topic))
+
+    selected = []
+    for template in templates:
+        anchored = "{topic}" in template
+        if anchored and not has_topic:
+            continue
+        selected.append((template, anchored))
+    return selected
+
+
+def _dedupe_results(results: list) -> list:
+    """Collapse hits found by more than one query, preserving first-seen order.
+
+    A result found by both a brand query and a topic query is topic material:
+    the topic flag wins, so shared hits are not stranded in the general pile.
+    """
+    seen = {}
+    order = []
+    for r in results:
+        key = (r.get("href") or "").strip().lower() or f"title:{r.get('title', '')}"
+        if key in seen:
+            if r.get("topic_anchored"):
+                seen[key]["topic_anchored"] = True
+            continue
+        seen[key] = r
+        order.append(key)
+    return [seen[k] for k in order]
+
+
+def _render_results(results: list) -> str:
+    """Render search hits as a markdown bullet list (include URLs)."""
+    lines = []
+    for r in results:
+        href = r.get("href", "")
+        if href:
+            lines.append(f"- [{r['title']}]({href}): {r['body']}")
+        else:
+            lines.append(f"- **{r['title']}**: {r['body']}")
+    return "\n".join(lines)
+
+
+def _format_results_block(results: list, brand_name: str, topic) -> str:
+    """Format search hits for the summariser prompt.
+
+    With a topic, results are split by provenance so the model can tell what
+    was actually found on the subject from what merely concerns the brand —
+    and so an empty topic section reads as an absence rather than as licence
+    to substitute general brand material for it.
+
+    With no topic, this is the flat list the prompt has always seen.
+    """
+    topic = _normalise_topic(topic)
+    if not topic:
+        return _render_results(results)
+
+    topical = [r for r in results if r.get("topic_anchored")]
+    general = [r for r in results if not r.get("topic_anchored")]
+
+    return "\n".join([
+        TOPIC_SECTION_HEADER.format(brand=brand_name, topic=topic),
+        _render_results(topical) if topical
+        else NO_TOPIC_RESULTS.format(brand=brand_name, topic=topic),
+        "",
+        GENERAL_SECTION_HEADER.format(brand=brand_name, topic=topic),
+        _render_results(general) if general else "(none)",
+    ])
+
+
+def run_skill(skill: dict, brand_name: str, topic: str = "", client_brief: str = "") -> dict:
+    """Execute a single research skill against a brand, on a given topic.
+
+    Runs the skill's search queries — brand-only plus, when the brief supplies
+    a topic, the skill's topic-anchored queries — then passes the raw results
+    through GPT-4o with the skill's prompt to produce a processed summary.
+
+    `topic` shapes what is searched for; `client_brief` is context for the
+    summariser only and is never turned into a search query.
 
     Returns dict with keys: skill_name, raw_results, processed_summary, error.
     """
     skill_name = skill["name"]
+    topic = _normalise_topic(topic)
     all_results = []
 
     timelimit = skill.get("timelimit", "y")
 
     try:
-        for i, query_template in enumerate(skill["queries"]):
+        for i, (query_template, anchored) in enumerate(_skill_queries(skill, topic)):
             if i > 0:
                 time.sleep(SEARCH_DELAY)
-            query = query_template.replace("{brand}", brand_name).replace("{year}", str(datetime.now().year))
+            query = (
+                query_template
+                .replace("{brand}", brand_name)
+                .replace("{topic}", topic)
+                .replace("{year}", str(datetime.now().year))
+            )
             results = _run_search(query, skill["max_results_per_query"], timelimit=timelimit)
-            all_results.extend(results)
+            for r in results:
+                all_results.append(dict(r, topic_anchored=anchored))
     except Exception as e:
         return {
             "skill_name": skill_name,
@@ -91,30 +253,32 @@ def run_skill(skill: dict, brand_name: str) -> dict:
             "error": str(e),
         }
 
+    all_results = _dedupe_results(all_results)
+
     if not all_results:
+        subject = f"{brand_name} and \"{topic}\"" if topic else brand_name
         return {
             "skill_name": skill_name,
             "raw_results": [],
-            "processed_summary": f"No search results found for {brand_name}.",
+            "processed_summary": f"No search results found for {subject}.",
             "error": None,
         }
 
-    # Format raw results as text for the GPT-4o prompt (include URLs)
-    raw_text = []
-    for r in all_results:
-        href = r.get("href", "")
-        if href:
-            raw_text.append(f"- [{r['title']}]({href}): {r['body']}")
-        else:
-            raw_text.append(f"- **{r['title']}**: {r['body']}")
-    raw_results_str = "\n".join(raw_text)
+    raw_results_str = _format_results_block(all_results, brand_name, topic)
 
     # Build the processing prompt from the skill template
     processing_prompt = skill["prompt"].replace(
         "{brand}", brand_name
     ).replace(
+        "{topic}", topic
+    ).replace(
         "{search_results}", raw_results_str
     )
+
+    if topic:
+        processing_prompt += _build_topic_directive(
+            brand_name, topic, client_brief, skill.get("topic_focus", TOPIC_FOCUS_LEAD)
+        )
 
     # Process through GPT-4o
     try:
@@ -134,14 +298,22 @@ def run_skill(skill: dict, brand_name: str) -> dict:
 
     return {
         "skill_name": skill_name,
-        "raw_results": [{"title": r["title"], "body": r["body"], "href": r.get("href", "")} for r in all_results],
+        "raw_results": [
+            {
+                "title": r["title"],
+                "body": r["body"],
+                "href": r.get("href", ""),
+                "topic_anchored": bool(r.get("topic_anchored")),
+            }
+            for r in all_results
+        ],
         "processed_summary": processed_summary,
         "error": None,
     }
 
 
-def research_advertiser(brand_name: str) -> list[dict]:
-    """Run all research skills against a brand and return results.
+def research_advertiser(brand_name: str, topic: str = "", client_brief: str = "") -> list[dict]:
+    """Run all research skills against a brand, on the brief's topic.
 
     Each skill runs independently — if one fails, others still complete.
     Returns a list of skill result dicts.
@@ -152,16 +324,16 @@ def research_advertiser(brand_name: str) -> list[dict]:
     for i, skill in enumerate(skills):
         if i > 0:
             time.sleep(SEARCH_DELAY)
-        result = run_skill(skill, brand_name)
+        result = run_skill(skill, brand_name, topic=topic, client_brief=client_brief)
         results.append(result)
 
     return results
 
 
 # Backward-compatible wrapper
-def search_advertiser(brand_name: str) -> str:
+def search_advertiser(brand_name: str, topic: str = "", client_brief: str = "") -> str:
     """Legacy interface — returns a single formatted string of brand research."""
-    skill_results = research_advertiser(brand_name)
+    skill_results = research_advertiser(brand_name, topic=topic, client_brief=client_brief)
     parts = []
     for sr in skill_results:
         parts.append(f"### {sr['skill_name']}\n{sr['processed_summary']}")

--- a/tests/test_synthesiser.py
+++ b/tests/test_synthesiser.py
@@ -516,3 +516,70 @@ def test_generate_insights_payload_is_json_serialisable():
 
     for key in ("audience_segments", "format_recommendations", "historical_research"):
         assert revived[key] == result[key]
+
+
+def test_advertiser_research_receives_the_topic_and_brief():
+    """#155: the topic and client brief must reach the advertiser research step."""
+    from unittest.mock import patch, MagicMock
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Test brief content"
+
+    empty_segments = {"matched": False, "note": "", "query_terms": [], "platforms": []}
+
+    with patch("src.synthesiser.research_advertiser", return_value=[]) as mock_research, \
+         patch("src.synthesiser.expand_query", return_value={"keywords": [], "categories": []}), \
+         patch("src.synthesiser.recommend_segments", return_value=empty_segments), \
+         patch("src.synthesiser.get_campaign_summary", return_value={"summary": "", "campaigns": []}), \
+         patch("src.synthesiser.summarise_brief", return_value="Festive food push in November.") as mock_summarise, \
+         patch("src.synthesiser.OpenAI") as mock_openai_cls:
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_cls.return_value = mock_client
+
+        from src.synthesiser import generate_insights
+        generate_insights(
+            topic="Christmas",
+            advertiser="Morrisons",
+            kpi="Reach",
+            include_google_trends=False,
+            client_brief="We want to drive festive food sales in November.",
+        )
+
+    assert mock_research.call_args.kwargs["topic"] == "Christmas"
+    assert mock_research.call_args.kwargs["client_brief"] == "Festive food push in November."
+    # The brief is summarised once and reused, not summarised twice.
+    assert mock_summarise.call_count == 1
+
+
+def test_advertiser_research_gets_no_brief_context_when_none_supplied():
+    """An absent brief must not reach research as the 'No client brief' sentinel."""
+    from unittest.mock import patch, MagicMock
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Test brief content"
+
+    empty_segments = {"matched": False, "note": "", "query_terms": [], "platforms": []}
+
+    with patch("src.synthesiser.research_advertiser", return_value=[]) as mock_research, \
+         patch("src.synthesiser.expand_query", return_value={"keywords": [], "categories": []}), \
+         patch("src.synthesiser.recommend_segments", return_value=empty_segments), \
+         patch("src.synthesiser.get_campaign_summary", return_value={"summary": "", "campaigns": []}), \
+         patch("src.synthesiser.OpenAI") as mock_openai_cls:
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_cls.return_value = mock_client
+
+        from src.synthesiser import generate_insights
+        generate_insights(
+            topic="Christmas",
+            advertiser="Morrisons",
+            kpi="Reach",
+            include_google_trends=False,
+        )
+
+    assert mock_research.call_args.kwargs["client_brief"] == ""

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,6 +1,16 @@
 from unittest.mock import patch, MagicMock
 
-from src.web_search import load_skills, _run_search, run_skill
+import pytest
+
+from src.web_search import (
+    _build_topic_directive,
+    load_skills,
+    research_advertiser,
+    _format_results_block,
+    _run_search,
+    _skill_queries,
+    run_skill,
+)
 
 
 def test_load_skills_finds_all():
@@ -113,3 +123,296 @@ def test_run_skill_substitutes_year_placeholder(mock_ddgs_cls):
     mock_instance.text.assert_called_once_with(
         expected_query, max_results=3, timelimit="y"
     )
+
+
+# ---------------------------------------------------------------------------
+# Topic-aware research (#155)
+#
+# The brief's topic has to reach the search step, or the research comes back
+# describing whatever the advertiser is best known for. These tests pin the
+# three seams: which queries run, how results are labelled, and what the
+# summariser is told to do with them.
+# ---------------------------------------------------------------------------
+
+
+def _skill(**overrides):
+    skill = {
+        "name": "Test Skill",
+        "queries": ['"{brand}" about company overview'],
+        "topic_queries": ['"{brand}" {topic}', '"{brand}" {topic} campaign'],
+        "max_results_per_query": 3,
+        "timelimit": "y",
+        "prompt": "Summarise results about {brand}:\n{search_results}",
+    }
+    skill.update(overrides)
+    return skill
+
+
+def test_every_skill_declares_topic_queries():
+    """Each shipped skill must have at least one topic-anchored query."""
+    for skill in load_skills():
+        assert skill["topic_queries"], f"{skill['name']} has no topic_queries"
+        for query in skill["topic_queries"]:
+            assert "{topic}" in query, f"{skill['name']} topic query missing {{topic}}: {query}"
+
+
+def test_topic_queries_default_to_empty_when_absent():
+    """A skill file without topic_queries still loads (backward compatible)."""
+    skill = _skill()
+    del skill["topic_queries"]
+    assert _skill_queries(skill, "gut health") == [('"{brand}" about company overview', False)]
+
+
+def test_skill_queries_include_topic_queries_when_topic_given():
+    queries = _skill_queries(_skill(), "gut health")
+    assert queries == [
+        ('"{brand}" about company overview', False),
+        ('"{brand}" {topic}', True),
+        ('"{brand}" {topic} campaign', True),
+    ]
+
+
+@pytest.mark.parametrize("topic", ["", "   ", None])
+def test_topic_queries_are_skipped_without_a_topic(topic):
+    """No topic must never become a blank substitution — the query is dropped."""
+    assert _skill_queries(_skill(), topic) == [('"{brand}" about company overview', False)]
+
+
+@patch("src.web_search.DDGS")
+def test_run_skill_searches_for_the_topic(mock_ddgs_cls):
+    """AC1: the topic reaches the search step and shapes what is searched for."""
+    mock_instance = MagicMock()
+    mock_instance.text.return_value = []
+    mock_ddgs_cls.return_value = mock_instance
+
+    with patch("src.web_search.OpenAI"), patch("src.web_search.time.sleep"):
+        run_skill(_skill(), "Morrisons", topic="Christmas")
+
+    issued = [call.args[0] for call in mock_instance.text.call_args_list]
+    assert '"Morrisons" about company overview' in issued
+    assert '"Morrisons" Christmas' in issued
+    assert '"Morrisons" Christmas campaign' in issued
+
+
+@patch("src.web_search.DDGS")
+def test_run_skill_without_topic_is_unchanged(mock_ddgs_cls):
+    """AC4: with no topic, the brand-only baseline runs exactly as before."""
+    mock_instance = MagicMock()
+    mock_instance.text.return_value = []
+    mock_ddgs_cls.return_value = mock_instance
+
+    with patch("src.web_search.OpenAI"), patch("src.web_search.time.sleep"):
+        run_skill(_skill(), "Morrisons")
+
+    issued = [call.args[0] for call in mock_instance.text.call_args_list]
+    assert issued == ['"Morrisons" about company overview']
+
+
+def test_results_block_separates_topic_from_general():
+    results = [
+        {"title": "Morrisons Christmas ad", "body": "Festive campaign", "href": "http://a", "topic_anchored": True},
+        {"title": "Morrisons kidswear", "body": "Nutmeg range", "href": "http://b", "topic_anchored": False},
+    ]
+    block = _format_results_block(results, "Morrisons", "Christmas")
+
+    assert "TOPIC-SPECIFIC" in block
+    assert "GENERAL BRAND" in block
+    # Each result sits under the right heading.
+    topic_part, general_part = block.split("GENERAL BRAND")
+    assert "Morrisons Christmas ad" in topic_part
+    assert "Morrisons kidswear" not in topic_part
+    assert "Morrisons kidswear" in general_part
+
+
+def test_results_block_states_when_no_topic_material_found():
+    """AC3: absence is reported, not quietly backfilled with brand material."""
+    results = [
+        {"title": "Morrisons kidswear", "body": "Nutmeg range", "href": "http://b", "topic_anchored": False},
+    ]
+    block = _format_results_block(results, "Morrisons", "Christmas")
+
+    topic_part = block.split("GENERAL BRAND")[0]
+    assert "none" in topic_part.lower()
+
+
+def test_results_block_is_a_flat_list_without_a_topic():
+    """No topic, no sectioning — the prompt sees what it saw before."""
+    results = [
+        {"title": "Morrisons kidswear", "body": "Nutmeg range", "href": "http://b", "topic_anchored": False},
+    ]
+    block = _format_results_block(results, "Morrisons", "")
+
+    assert "TOPIC-SPECIFIC" not in block
+    assert block == "- [Morrisons kidswear](http://b): Nutmeg range"
+
+
+@patch("src.web_search.DDGS")
+def test_run_skill_dedupes_and_keeps_the_topic_flag(mock_ddgs_cls):
+    """A hit found by both a brand and a topic query counts as topic material once."""
+    mock_instance = MagicMock()
+    mock_instance.text.side_effect = [
+        [{"title": "Shared", "body": "Same article", "href": "http://same"}],
+        [{"title": "Shared", "body": "Same article", "href": "http://same"}],
+        [],
+    ]
+    mock_ddgs_cls.return_value = mock_instance
+
+    with patch("src.web_search.OpenAI"), patch("src.web_search.time.sleep"):
+        result = run_skill(_skill(), "Morrisons", topic="Christmas")
+
+    assert len(result["raw_results"]) == 1
+    assert result["raw_results"][0]["topic_anchored"] is True
+
+
+@patch("src.web_search.DDGS")
+def test_run_skill_prompt_carries_topic_and_brief(mock_ddgs_cls):
+    """The summariser is told the subject and how to handle a thin topic section."""
+    mock_instance = MagicMock()
+    mock_instance.text.return_value = [
+        {"title": "T", "body": "B", "href": "http://x"}
+    ]
+    mock_ddgs_cls.return_value = mock_instance
+
+    with patch("src.web_search.OpenAI") as mock_openai_cls, patch("src.web_search.time.sleep"):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        run_skill(
+            _skill(),
+            "Morrisons",
+            topic="Christmas",
+            client_brief="Drive festive food sales in November.",
+        )
+
+    prompt = mock_client.chat.completions.create.call_args[1]["messages"][1]["content"]
+    assert "Christmas" in prompt
+    assert "Drive festive food sales in November." in prompt
+    assert "TOPIC-SPECIFIC" in prompt
+    # The instruction that stops general material being passed off as topic material.
+    assert "Do not pad" in prompt
+
+
+@patch("src.web_search.DDGS")
+def test_run_skill_prompt_has_no_topic_directive_without_a_topic(mock_ddgs_cls):
+    mock_instance = MagicMock()
+    mock_instance.text.return_value = [
+        {"title": "T", "body": "B", "href": "http://x"}
+    ]
+    mock_ddgs_cls.return_value = mock_instance
+
+    with patch("src.web_search.OpenAI") as mock_openai_cls, patch("src.web_search.time.sleep"):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        run_skill(_skill(), "Morrisons")
+
+    prompt = mock_client.chat.completions.create.call_args[1]["messages"][1]["content"]
+    assert "Brief context" not in prompt
+    assert "TOPIC-SPECIFIC" not in prompt
+
+
+@patch("src.web_search.DDGS")
+def test_run_skill_substitutes_topic_in_the_prompt_body(mock_ddgs_cls):
+    """Skill authors can reference {topic} in the prompt body itself."""
+    mock_instance = MagicMock()
+    mock_instance.text.return_value = [
+        {"title": "T", "body": "B", "href": "http://x"}
+    ]
+    mock_ddgs_cls.return_value = mock_instance
+
+    skill = _skill(prompt="Report on {brand} and {topic}:\n{search_results}")
+    with patch("src.web_search.OpenAI") as mock_openai_cls, patch("src.web_search.time.sleep"):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        run_skill(skill, "Morrisons", topic="Christmas")
+
+    prompt = mock_client.chat.completions.create.call_args[1]["messages"][1]["content"]
+    assert "Report on Morrisons and Christmas:" in prompt
+
+
+@patch("src.web_search.DDGS")
+def test_no_results_message_names_the_topic(mock_ddgs_cls):
+    mock_instance = MagicMock()
+    mock_instance.text.return_value = []
+    mock_ddgs_cls.return_value = mock_instance
+
+    with patch("src.web_search.OpenAI"), patch("src.web_search.time.sleep"):
+        result = run_skill(_skill(), "Morrisons", topic="Christmas")
+
+    assert "Christmas" in result["processed_summary"]
+
+
+@patch("src.web_search.load_skills")
+def test_research_advertiser_forwards_topic_and_brief(mock_load_skills):
+    mock_load_skills.return_value = [_skill(), _skill(name="Second")]
+
+    with patch("src.web_search.run_skill", return_value={}) as mock_run_skill, \
+         patch("src.web_search.time.sleep"):
+        research_advertiser("Morrisons", topic="Christmas", client_brief="Festive food.")
+
+    for call in mock_run_skill.call_args_list:
+        assert call.kwargs["topic"] == "Christmas"
+        assert call.kwargs["client_brief"] == "Festive food."
+
+
+# ---------------------------------------------------------------------------
+# Per-skill topic focus (#155, AC4)
+#
+# `topic` is a required API field, so every production brief takes the topic
+# path — the no-topic path is unreachable there and proves nothing about
+# "thick-roster briefs are no worse". Skills differ in what the topic should do
+# to them: Company Overview feeds the brief's Advertiser Overview section and
+# must stay brand-complete; the others should lead with the topic.
+# ---------------------------------------------------------------------------
+
+
+def test_company_overview_supplements_rather_than_leads():
+    overview = [s for s in load_skills() if s["name"] == "Company Overview"][0]
+    assert overview["topic_focus"] == "supplement"
+
+
+def test_other_skills_lead_with_the_topic():
+    for skill in load_skills():
+        if skill["name"] == "Company Overview":
+            continue
+        assert skill["topic_focus"] == "lead", skill["name"]
+
+
+def test_topic_focus_defaults_to_lead():
+    """A skill file that says nothing about focus leads with the topic."""
+    skill = _skill()
+    assert skill.get("topic_focus", "lead") == "lead"
+    directive = _build_topic_directive("Morrisons", "Christmas", "", None)
+    assert "Lead with the TOPIC-SPECIFIC results" in directive
+
+
+def test_supplement_directive_protects_the_general_overview():
+    """AC4: a supplement skill keeps its brand-general material intact."""
+    directive = _build_topic_directive("Morrisons", "Christmas", "", "supplement")
+
+    assert "do not drop it" in directive
+    # The instruction that would have thinned the Advertiser Overview section.
+    assert "only as supporting context" not in directive
+
+
+def test_both_focuses_keep_the_thin_topic_rule():
+    """AC3 holds whichever way a skill is focused."""
+    for focus in ("lead", "supplement"):
+        directive = _build_topic_directive("Morrisons", "Christmas", "", focus)
+        assert "Do not pad" in directive
+        assert "Little material found" in directive
+
+
+@patch("src.web_search.DDGS")
+def test_run_skill_uses_the_skills_topic_focus(mock_ddgs_cls):
+    mock_instance = MagicMock()
+    mock_instance.text.return_value = [
+        {"title": "T", "body": "B", "href": "http://x"}
+    ]
+    mock_ddgs_cls.return_value = mock_instance
+
+    with patch("src.web_search.OpenAI") as mock_openai_cls, patch("src.web_search.time.sleep"):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        run_skill(_skill(topic_focus="supplement"), "Morrisons", topic="Christmas")
+
+    prompt = mock_client.chat.completions.create.call_args[1]["messages"][1]["content"]
+    assert "do not drop it" in prompt


### PR DESCRIPTION
Closes #155. Part of the August 2026 QA round (#154) — first ticket in the working order.

## The bug

The advertiser research took only the advertiser's *name*. The topic never reached it, so the searches were literally `"Morrisons" news announcements latest` and the model was faithfully summarising what it had been handed: general brand material. A Christmas brief for Morrisons came back about their kidswear brand; a gut-health brief for Patagonia came back about outdoor gear.

The issue said this was not the model drifting off topic, and it was right. No prompt rewording could have fixed it — the topic-specific pages were never fetched.

## The fix

Three seams, deliberately separate:

**1. `topic_queries` in skill frontmatter** — searches that actually name the topic, run only when the brief supplies one. The brand-only baseline still runs untouched. A template mentioning `{topic}` is *dropped* when there is no topic rather than substituted blank; a blank substitution collapses the query back to brand-only, which is the original bug in disguise.

**2. Provenance on every result.** Hits carry `topic_anchored` and render to the summariser in two labelled sections. When nothing topic-specific was found the section prints an explicit marker rather than vanishing, so the model sees an absence instead of inferring it from silence:

```
TOPIC-SPECIFIC RESULTS — Morrisons in relation to "Christmas":
(none — searches for Morrisons and "Christmas" returned nothing)

GENERAL BRAND RESULTS — Morrisons only, not specific to "Christmas":
- [Morrisons kidswear Nutmeg](http://…): Nutmeg clothing range
```

**3. The topic directive is composed in `web_search.py`, not written into each `skills/*.md`.** Skills stay drop-in extensible (adding a `.md` still needs no code change) *and* no skill — including one added later by someone who never read this — can opt out of the rule that general brand material must not be presented as topic material.

`generate_insights()` now summarises the client brief up front so research can read it as context. Still one LLM call, just earlier. The brief shapes the *reading*; it never becomes a search query.

## Per-skill `topic_focus` — and the defect the review caught

The first version of this branch applied one directive to every skill: use general brand material "only as supporting context, and only where it bears on the topic". That would have thinned the brief's **Advertiser Overview** section, which needs scale, positioning, customers and group structure whatever the brief asks about — fixing the reported bug by causing a quieter one.

Frontmatter `topic_focus` now picks the strength. Company Overview is `supplement` (keep the general picture whole, add a topic passage); the rest are `lead` (default).

Related: the test originally written as evidence for AC4 proved nothing. `topic` is a required field on `InsightsRequest`, so the no-topic path is unreachable in production and *every* real brief takes the topic path. Recorded in LESSONS_LEARNED.md.

## Acceptance criteria

- [x] **The brief's topic reaches the advertiser research step and shapes what is searched for** — deterministic. `generate_insights` passes `topic=`; `_skill_queries` appends topic templates; `run_skill` substitutes `{topic}` into the issued query.
- [x] **A brief for an advertiser with a topic outside their best-known activity returns research on that topic** — *partly deterministic.* Code guarantees topic material is fetched and presented first; that it dominates the summary rests on the prompt directive, and general results still outnumber topic ones 9:6. Named plainly because the issue warns against prompt-level fixes.
- [x] **Where little topic-specific material exists, the output says so** — the `(none — …)` marker is deterministic; the "little material found" sentence depends on the model obeying the directive.
- [x] **Briefs for thick-roster advertisers are no worse than they are today** — protected by `topic_focus: supplement` on Company Overview, not by the unreachable no-topic path.

## Cost

Searches per brief go from 9 to 15 when a topic is present — roughly **+9s** of rate-limit delay. Accepted as the price of the fix, not overlooked.

## Testing

23 new tests. Full suites green: **499 backend** (pytest), **39 frontend** (vitest), `tsc --noEmit` clean.

Reviewed on both axes with `/code-review` (standards + spec) before commit; the `topic_focus` split and the contract/annotation tidy-ups came out of that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
