### PR TITLE
Floor recommended audience segments at a minimum reach (#159)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ EMBEDDING_MODEL=text-embedding-3-small
 CHAT_MODEL=gpt-4o
 CHUNK_SIZE=500
 CHUNK_OVERLAP=50
+# Audience segments below this reach are never recommended (0 disables the floor)
+MIN_SEGMENT_REACH=5000
 
 # Chroma Cloud (optional — leave empty for local ChromaDB)
 CHROMA_CLOUD_API_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Requires a `.env` file at root with:
 - `JWT_SECRET` (required — no default, app will not start without it)
 - `DATABASE_URL` (defaults to `sqlite:///users.db` for local dev)
 
-Optional overrides: `CHROMA_PERSIST_DIR`, `EMBEDDING_MODEL`, `CHAT_MODEL`, `CHUNK_SIZE`, `CHUNK_OVERLAP`.
+Optional overrides: `CHROMA_PERSIST_DIR`, `EMBEDDING_MODEL`, `CHAT_MODEL`, `CHUNK_SIZE`, `CHUNK_OVERLAP`, `MIN_SEGMENT_REACH`.
 
 Optional Chroma Cloud: `CHROMA_CLOUD_API_KEY`, `CHROMA_CLOUD_TENANT`, `CHROMA_CLOUD_DATABASE` (leave empty for local ChromaDB).
 
@@ -84,7 +84,7 @@ Prism Data Vault is a RAG-based advertising strategy insights tool. The frontend
 
 1. **Editorial transcripts** — JSON files in `data/transcripts/`, embedded into ChromaDB (`src/embeddings.py`, `src/vectorstore.py`)
 2. **Advertiser web research** — skill-based DuckDuckGo + GPT-4o (`src/web_search.py`)
-3. **Audience data** — CSV trends in `data/audience_trends.csv` (`src/audience.py`)
+3. **Audience segments** — canonical Permutive + AudienceProject rows in `data/segments.csv`, matched and ranked by `src/audience.py`. Segments below `config.MIN_SEGMENT_REACH` (default 5,000) are dropped at recommendation time, not at ingest, so the CSV stays the faithful record of what the platforms returned and the floor can move without a rebuild
 4. **Google Trends** — live pytrends data (`src/trends.py`)
 5. **Format recommendations** — ad format benchmarks in `data/format_recommendations.csv` (`src/formats.py`)
 6. **Client brief summary** — optional GPT-4o summarisation (`src/brief.py`)
@@ -146,7 +146,7 @@ DuckDuckGo searches use the `ddgs` package (not the deprecated `duckduckgo_searc
 
 ### Key data contracts
 
-- `generate_insights()` returns: `{content, sources, research_skills, audience_timing, google_trends, format_recommendations, client_brief_summary}`
+- `generate_insights()` returns: `{content, sources, research_skills, audience_segments, google_trends, format_recommendations, campaign_history, client_brief_summary, historical_research}`
 - Each skill result: `{skill_name, raw_results, processed_summary, error}`; each entry in `raw_results` is `{title, body, href, topic_anchored}`, where `topic_anchored` records whether that hit came from a topic query or a brand-only one
 - `USER_PROMPT_TEMPLATE` placeholders: `{topic}`, `{advertiser}`, `{advertiser_kpi}`, `{editorial_insights}`, `{advertiser_research}`, `{audience_timing}`, `{google_trends}`, `{format_recommendations}`, `{client_brief}`
 

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -453,3 +453,53 @@ fixes. Trace the parameter, then judge the wording.
 **Cost, recorded honestly:** searches per brief go from 9 to 15 when a topic is
 present, roughly +9s of rate-limit delay. That was accepted as the price of the
 fix, not overlooked.
+
+## 2026-08-05 — Where a filter sits decides what it filters (#159)
+
+**What went wrong.** Recommended audiences included segments of 30, 13 and 5
+people. Ranking was relevance-first, reach-second with no floor, so a perfectly
+on-topic segment of five people outranked a broad one. 116 of 1,385 segments sit
+below a reach of 5,000; 38 are below 100, with the smallest at 1, 2 and 3 —
+noise, not small audiences.
+
+**The fix.** A `MIN_SEGMENT_REACH` floor (default 5,000, env-overridable),
+applied inside `recommend_segments` rather than in the CSV or at load.
+
+**The decision that mattered: _where_ in the function.** The floor is applied to
+the candidate pool as the first statement, before matching, weighting and
+capping — not to the final list on the way out. Filtering on the way out looks
+equivalent and isn't:
+
+1. The match ladder broadens to category-only matches when fewer than three
+   keyword hits are found. Filtering afterwards lets three sub-floor hits
+   suppress the broadening and _then_ get dropped, returning nothing when the
+   ladder would have found usable segments.
+2. The per-platform cap of 8 is applied before an outbound filter would run, so
+   sub-floor segments would eat slots and hand back a short list rather than the
+   next most relevant segment above the floor — which is precisely what the
+   acceptance criteria asked for.
+
+**Recommendation time, not ingest.** `data/segments.csv` stays the faithful
+record of what Permutive and AudienceProject returned. Stripping rows at ingest
+would have been fewer lines and would have made the threshold un-moveable
+without a data rebuild, and lost the ability to answer "what did the platform
+actually return?".
+
+**Two consequences worth naming rather than discovering later.** Filtering at
+the top also moves the IDF base — keyword weights are now computed over 1,269
+segments, not 1,385 — so the comment claiming weights come from "the whole
+catalogue" had to be corrected rather than left to mislead the next reader. And
+the floor is scoped to the recommender: the Assistant's `search_segments`
+answers "what segments exist?", not "what should I buy?", so it still sees
+everything. That is a decision, and it is written down in `_drop_below_reach_floor`
+where someone looking for it will find it.
+
+**Watch the fixtures when you add a floor.** `test_capped_at_eight_per_platform`
+built its ten segments with reaches of 1,000–10,000; four fell below the new
+floor and the cap test broke for a reason unrelated to capping. Test data
+chosen when a constraint didn't exist will quietly violate it later — scale the
+fixture, don't weaken the floor.
+
+**Transferable lesson:** a filter's position in a pipeline is part of its
+specification. "Exclude X" and "exclude X _before_ the fallback and the cap"
+produce different outputs on exactly the inputs the bug report is about.

--- a/config.py
+++ b/config.py
@@ -22,6 +22,10 @@ EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
 CHAT_MODEL = os.getenv("CHAT_MODEL", "gpt-4o")
 CHUNK_SIZE = int(os.getenv("CHUNK_SIZE", "500"))
 CHUNK_OVERLAP = int(os.getenv("CHUNK_OVERLAP", "50"))
+# Audience segments below this reach are too small to plan against and are never
+# recommended. Set to 0 to disable the floor. See src/audience.py for why it is
+# applied at recommendation time rather than at ingest.
+MIN_SEGMENT_REACH = int(os.getenv("MIN_SEGMENT_REACH", "5000"))
 # Signup is restricted to these email domains. Comma-separated, case-insensitive.
 # Set ALLOWED_EMAIL_DOMAINS="" to allow any domain (local dev / open demo only).
 ALLOWED_EMAIL_DOMAINS = [

--- a/src/audience.py
+++ b/src/audience.py
@@ -168,15 +168,35 @@ def _relevance_score(segment, keyword_weights):
     return score
 
 
+def _reach_of(segment):
+    """Reach as an int; 0 when the source value is missing or unreadable."""
+    try:
+        return int(float(segment.get("reach")))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _drop_below_reach_floor(segments, min_reach):
+    """Drop segments too small to plan against (#159).
+
+    Applied here, at recommendation time, rather than at ingest, so
+    data/segments.csv remains the faithful record of what Permutive and
+    AudienceProject returned. Segments whose reach cannot be read are treated
+    as below the floor — an unreadable figure is not something to plan against
+    either.
+
+    Scope is the recommender only. The Assistant's `search_segments`
+    (src/assistant.py) answers "what segments exist?" rather than "what should
+    I buy?", so it still sees the whole catalogue on purpose.
+    """
+    return [s for s in segments if _reach_of(s) >= min_reach]
+
+
 def _to_item(segment):
     """Project a raw segment row into a clean payload item (reach as int)."""
-    try:
-        reach = int(float(segment.get("reach")))
-    except (TypeError, ValueError):
-        reach = 0
     return {
         "segment_name": segment.get("segment_name", ""),
-        "reach": reach,
+        "reach": _reach_of(segment),
         "platform": segment.get("platform", ""),
         "category": segment.get("category", ""),
         "plain_english": segment.get("plain_english", ""),
@@ -213,17 +233,33 @@ def _match_with_fallback(segments, keywords, categories):
 
 
 def recommend_segments(advertiser, topic, client_brief="", segments=None,
-                       expansion=None, client=None, per_platform_limit=8):
+                       expansion=None, client=None, per_platform_limit=8,
+                       min_reach=None):
     # type: (...) -> dict
-    """Return the deterministic audience_segments payload."""
+    """Return the deterministic audience_segments payload.
+
+    `min_reach` defaults to `config.MIN_SEGMENT_REACH`; pass 0 to recommend from
+    the whole catalogue.
+    """
     if segments is None:
         segments = load_segments()
+
+    # The floor is applied to the candidate pool before anything else, so the
+    # match ladder, the relevance weights and the per-platform cap all work over
+    # segments that are actually buyable. A brief that would once have surfaced
+    # a sub-floor segment now gets the next most relevant one above it. The
+    # config default is read here, at call time, so moving the threshold is an
+    # environment change rather than a restart-and-rebuild.
+    if min_reach is None:
+        min_reach = getattr(config, "MIN_SEGMENT_REACH", 5000)
+    segments = _drop_below_reach_floor(segments, min_reach)
 
     keywords = list(expansion.get("keywords", [])) if expansion else []
     categories = list(expansion.get("categories", [])) if expansion else []
 
     matched = _match_with_fallback(segments, keywords, categories)
-    # Relevance weights are computed over the whole catalogue so a rare, on-topic
+    # Relevance weights are computed over every segment that could be recommended
+    # — the catalogue after the floor, not the raw file — so a rare, on-topic
     # keyword ("gut") outweighs a common one ("food"). Segments are then ranked
     # by relevance first, reach second — so the most relevant niche segments are
     # never buried under generic high-reach ones (and cut by the per-platform cap).
@@ -233,7 +269,7 @@ def recommend_segments(advertiser, topic, client_brief="", segments=None,
     for platform in _PLATFORM_ORDER:
         rows = [s for s in matched if s.get("platform") == platform]
         rows.sort(
-            key=lambda s: (_relevance_score(s, weights), _to_item(s)["reach"]),
+            key=lambda s: (_relevance_score(s, weights), _reach_of(s)),
             reverse=True,
         )
         platforms.append({

--- a/tests/test_audience.py
+++ b/tests/test_audience.py
@@ -4,9 +4,13 @@ The deterministic engine (match / rank / fallback) is exercised through
 `recommend_segments` with injected `segments` and `expansion`, so no test here
 touches OpenAI or the real data/segments.csv.
 """
-from unittest.mock import MagicMock
+import csv
+import os
+from unittest.mock import MagicMock, patch
 
-from src.audience import recommend_segments, expand_query, format_audience_segments
+from src.audience import (
+    recommend_segments, expand_query, format_audience_segments, load_segments,
+)
 
 
 def _fixtures():
@@ -68,10 +72,10 @@ def test_reach_is_int_copied_verbatim_from_source():
 
 
 def test_capped_at_eight_per_platform_ordered_by_reach_desc():
-    # 10 matching Permutive segments with ascending reach.
+    # 10 matching Permutive segments with ascending reach, all above the floor.
     segs = [
         {"segment_name": "Baking Fans %d" % i, "platform": "Permutive",
-         "reach": str((i + 1) * 1000), "category": "Food & Drink",
+         "reach": str((i + 1) * 10000), "category": "Food & Drink",
          "description": "baking", "plain_english": "Browses baking", "code": str(i),
          "frequency": "R", "window": "All Time", "icon_key": "food-drink"}
         for i in range(10)
@@ -84,7 +88,7 @@ def test_capped_at_eight_per_platform_ordered_by_reach_desc():
     assert len(perm) == 8  # capped
     reaches = [s["reach"] for s in perm]
     assert reaches == sorted(reaches, reverse=True)  # ordered by reach desc
-    assert reaches[0] == 10000  # the largest survived the cap
+    assert reaches[0] == 100000  # the largest survived the cap
 
 
 def _all_keys(obj):
@@ -249,6 +253,159 @@ def test_matching_is_stem_based_not_just_exact():
     )
     names = [s["segment_name"] for p in payload["platforms"] for s in p["segments"]]
     assert "Home Bakers" in names
+
+
+# --- Minimum reach floor (#159) -------------------------------------------
+
+
+def _tiny_and_usable():
+    """One unbuyably small segment and one usable one, both on-topic."""
+    return [
+        {"segment_name": "Sourdough Starter Obsessives", "platform": "Permutive",
+         "reach": "13", "category": "Food & Drink",
+         "description": "browsed for sourdough baking content",
+         "plain_english": "Browses sourdough content", "code": "1",
+         "frequency": "R", "window": "All Time", "icon_key": "food-drink"},
+        {"segment_name": "Home Bakers", "platform": "Permutive", "reach": "70000",
+         "category": "Food & Drink", "description": "browsed for baking content",
+         "plain_english": "Browses baking content", "code": "2",
+         "frequency": "R", "window": "All Time", "icon_key": "food-drink"},
+    ]
+
+
+def test_segments_below_the_reach_floor_are_excluded():
+    payload = recommend_segments(
+        advertiser="X", topic="baking", segments=_tiny_and_usable(),
+        expansion={"keywords": ["baking", "sourdough"], "categories": []},
+    )
+    names = [s["segment_name"] for p in payload["platforms"] for s in p["segments"]]
+    assert "Sourdough Starter Obsessives" not in names
+    assert "Home Bakers" in names
+
+
+def test_next_most_relevant_above_the_floor_takes_the_slot():
+    # "sourdough" is the rarer keyword, so without a floor the 13-reach segment
+    # ranks first. With the floor it is dropped and the next most relevant
+    # segment above the floor is recommended in its place.
+    segs = _tiny_and_usable()
+    expansion = {"keywords": ["baking", "sourdough"], "categories": []}
+
+    unfloored = recommend_segments(
+        advertiser="X", topic="baking", segments=segs,
+        expansion=expansion, min_reach=0,
+    )
+    perm = _by_platform(unfloored)["Permutive"]["segments"]
+    assert perm[0]["segment_name"] == "Sourdough Starter Obsessives"
+
+    floored = recommend_segments(
+        advertiser="X", topic="baking", segments=segs, expansion=expansion,
+    )
+    perm = _by_platform(floored)["Permutive"]["segments"]
+    assert perm[0]["segment_name"] == "Home Bakers"
+
+
+def test_floor_boundary_is_inclusive_at_5000():
+    segs = [
+        {"segment_name": "Just Under", "platform": "Permutive", "reach": "4999",
+         "category": "Food & Drink", "description": "baking",
+         "plain_english": "Browses baking", "code": "1",
+         "frequency": "R", "window": "All Time", "icon_key": "food-drink"},
+        {"segment_name": "Exactly At", "platform": "Permutive", "reach": "5000",
+         "category": "Food & Drink", "description": "baking",
+         "plain_english": "Browses baking", "code": "2",
+         "frequency": "R", "window": "All Time", "icon_key": "food-drink"},
+    ]
+    payload = recommend_segments(
+        advertiser="X", topic="baking", segments=segs,
+        expansion={"keywords": ["baking"], "categories": []},
+    )
+    names = [s["segment_name"] for p in payload["platforms"] for s in p["segments"]]
+    assert names == ["Exactly At"]
+
+
+def test_threshold_is_configurable_without_touching_the_dataset():
+    segs = _tiny_and_usable()
+    expansion = {"keywords": ["baking", "sourdough"], "categories": []}
+
+    # Explicit override at the call site.
+    off = recommend_segments("X", "baking", segments=segs, expansion=expansion,
+                             min_reach=0)
+    assert len(_by_platform(off)["Permutive"]["segments"]) == 2
+
+    # Config-driven default, read at call time so an env change is enough.
+    with patch("config.MIN_SEGMENT_REACH", 100000):
+        raised = recommend_segments("X", "baking", segments=segs, expansion=expansion)
+    assert raised["matched"] is False
+
+
+def test_segments_with_unreadable_reach_are_treated_as_below_the_floor():
+    segs = [
+        {"segment_name": "Blank Reach", "platform": "Permutive", "reach": "",
+         "category": "Food & Drink", "description": "baking",
+         "plain_english": "Browses baking", "code": "1",
+         "frequency": "R", "window": "All Time", "icon_key": "food-drink"},
+        {"segment_name": "Home Bakers", "platform": "Permutive", "reach": "70000",
+         "category": "Food & Drink", "description": "baking",
+         "plain_english": "Browses baking", "code": "2",
+         "frequency": "R", "window": "All Time", "icon_key": "food-drink"},
+    ]
+    payload = recommend_segments(
+        advertiser="X", topic="baking", segments=segs,
+        expansion={"keywords": ["baking"], "categories": []},
+    )
+    names = [s["segment_name"] for p in payload["platforms"] for s in p["segments"]]
+    assert names == ["Home Bakers"]
+
+
+def test_floor_applies_before_the_category_fallback_ladder():
+    # Two keyword hits are below the floor, leaving one eligible keyword match —
+    # under the ladder's threshold — so category broadening must still fire.
+    segs = [
+        {"segment_name": "Allotment Growers", "platform": "Permutive", "reach": "50000",
+         "category": "Gardening", "description": "browsed for garden allotment content",
+         "plain_english": "Browses allotment content", "code": "1",
+         "frequency": "R", "window": "All Time", "icon_key": "gardening"},
+        {"segment_name": "Garden Pond Owners", "platform": "Permutive", "reach": "40",
+         "category": "Gardening", "description": "browsed for garden pond content",
+         "plain_english": "Browses pond content", "code": "2",
+         "frequency": "R", "window": "All Time", "icon_key": "gardening"},
+        {"segment_name": "Garden Furniture Buyers", "platform": "Permutive", "reach": "900",
+         "category": "Gardening", "description": "browsed for garden furniture content",
+         "plain_english": "Browses furniture content", "code": "3",
+         "frequency": "R", "window": "All Time", "icon_key": "gardening"},
+        {"segment_name": "Rose Enthusiasts", "platform": "Permutive", "reach": "40000",
+         "category": "Gardening", "description": "browsed for rose growing content",
+         "plain_english": "Browses rose content", "code": "4",
+         "frequency": "R", "window": "All Time", "icon_key": "gardening"},
+    ]
+    payload = recommend_segments(
+        advertiser="GardenCo", topic="gardening", segments=segs,
+        expansion={"keywords": ["garden"], "categories": ["Gardening"]},
+    )
+    names = [s["segment_name"] for p in payload["platforms"] for s in p["segments"]]
+    assert "Allotment Growers" in names
+    assert "Rose Enthusiasts" in names  # pulled in by the broadened ladder
+    assert "Garden Pond Owners" not in names
+    assert "Garden Furniture Buyers" not in names
+
+
+def test_floor_is_applied_at_recommendation_time_not_at_load(tmp_path):
+    # segments.csv stays the faithful record of what Permutive and AP returned;
+    # nothing is stripped on the way in.
+    path = os.path.join(str(tmp_path), "segments.csv")
+    fields = ["segment_name", "platform", "reach", "category", "description",
+              "plain_english", "code", "frequency", "window", "icon_key"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for row in _tiny_and_usable():
+            writer.writerow(row)
+
+    loaded = load_segments(path)
+    assert [r["segment_name"] for r in loaded] == [
+        "Sourdough Starter Obsessives", "Home Bakers",
+    ]
+    assert loaded[0]["reach"] == "13"
 
 
 def _fake_client(content):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,6 +93,18 @@ def test_chroma_cloud_vars_default_to_empty():
     assert cfg.CHROMA_CLOUD_DATABASE == ""
 
 
+def test_min_segment_reach_defaults_to_5000():
+    """The recommendation-time reach floor defaults to 5,000 (#159)."""
+    cfg = _reload_config({"MIN_SEGMENT_REACH": None})
+    assert cfg.MIN_SEGMENT_REACH == 5000
+
+
+def test_min_segment_reach_from_env():
+    """The floor can be moved without rebuilding the segment dataset."""
+    cfg = _reload_config({"MIN_SEGMENT_REACH": "10000"})
+    assert cfg.MIN_SEGMENT_REACH == 10000
+
+
 def test_chroma_cloud_vars_from_env():
     """Chroma Cloud vars should be read from environment when set."""
     cfg = _reload_config({


### PR DESCRIPTION
Closes #159. Part of #154 (QA round, August 2026).

## The bug

Segments are ranked relevance-first, reach-second. Relevance is IDF-weighted so a rare keyword ("gut") outscores a common one ("food") — deliberate, so niche on-topic segments aren't buried under generic mass-reach ones. With no size floor underneath it, that same rule let a perfectly on-topic segment of five people outrank a broad one.

> "Some recommended audiences are far too small to actually use, sizes of 30, 13 and in one case 5" — Abel

The tail is larger than that sample: 116 of 1,385 segments are below a reach of 5,000, 38 below 100, smallest at 1, 2 and 3 — noise, not small audiences.

## The change

- `config.MIN_SEGMENT_REACH` — default 5,000, overridable via the `MIN_SEGMENT_REACH` env var (0 disables the floor).
- `recommend_segments()` drops sub-floor segments from the candidate pool as its first act.

**Where the filter sits is the design decision.** Filtering the final list on the way out looks equivalent and isn't. Two things run before that list exists:

1. The match ladder broadens to category-only matches when fewer than three keyword hits are found. Filter last, and three sub-floor hits satisfy the ladder, suppress the broadening, and *then* get dropped — returning nothing where usable segments existed.
2. The per-platform cap of 8 is applied before an outbound filter would run, so sub-floor segments eat slots and hand back a short list rather than the next most relevant segment above the floor.

Filtering first makes AC4 true by construction.

## Acceptance criteria

- [x] Segments with a reach below 5,000 are excluded from recommendations
- [x] The floor is applied at recommendation time, not at ingest — `segments.csv` remains the faithful record of what Permutive and AudienceProject returned
- [x] The threshold can be changed without rebuilding the segment dataset
- [x] A brief that previously surfaced a sub-5,000 segment now returns the next most relevant one above the floor

Verified live against the real dataset: 1,385 rows loaded, 1,269 eligible — the ticket's figures exactly.

## Scope call worth a reviewer's eye

The floor covers the brief recommender only. `src/assistant.py`'s `search_segments` reads the same CSV and still sees the whole catalogue — chat answers "what segments exist?", not "what should I buy?". The decision is documented in `_drop_below_reach_floor` rather than left silent. It sits next to #164, which touches Assistant segment handling.

Two consequences named rather than left to be discovered: the IDF base moves to 1,269 (a now-corrected comment claimed weights came from "the whole catalogue"), and rows with unreadable reach are treated as below the floor — no live impact, all 1,385 rows parse cleanly.

## Tests

TDD — 8 tests written red first: exclusion, inclusive boundary at exactly 5,000, configurability at both the call site and via config, unreadable reach, floor-before-the-ladder, and `load_segments()` still returning sub-floor rows. One existing cap fixture was scaled up: it built reaches of 1,000–10,000, four of which fell below the new floor, breaking the cap test for a reason unrelated to capping.

508 Python tests pass, 39 frontend tests pass, typecheck clean.

Reviewed with `/code-review` on both the standards and spec axes; findings applied in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)