### PR TITLE
Require subject relevance in the historical research gate (#157)

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -648,3 +648,25 @@ gives up automatic coverage of unwritten files in exchange for never guessing
 wrong about the file in front of it. For a catalogue of one, curated by hand,
 that is the right trade — and it is the same reason the segment gate in #164
 needed its guard pointed at real inputs rather than a plausible-looking list.
+
+**Postscript — `\b` is the wrong boundary for a hand-authored term list.** The
+spec review found a trap I had walked closer to rather than away from. The gate
+guarded whole words with `r"\b" + re.escape(needle) + r"\b"`, which cannot ever
+match a term ending in punctuation: `\b55\+\b` demands a word character
+immediately after the `+`, so the term `55+` is silently dead. Nothing errors,
+no test fails — the term just never fires. That is the worst failure mode for a
+list a human curates by hand, and #157's own ticket wording is "a 55+ audience",
+so the very next author would have hit it. Fixed by defining the boundary by
+what sits _outside_ the needle — `(?<!\w)needle(?!\w)` — which matches `55+` and
+still refuses `rail` inside `email` (both directions are pinned by tests). The
+general lesson: `\b` is a boundary _between_ word and non-word characters, so it
+is only equivalent to "whole token" when the token starts and ends with word
+characters. Domain vocabularies rarely promise that.
+
+**And a claim-discipline catch.** The first version of the frontmatter comment
+called `audience_terms` "who this research surveyed". It isn't — the survey base
+is a general UK panel of 1,589 with no age or affluence screen, and the terms
+come from the file's own "best fit" passages. In a product whose whole selling
+point is defensible sourcing, a comment that turns a positioning statement into
+a sample definition is the same over-claim the prompt's citation rules exist to
+prevent. Reworded to "who this research speaks to", with the real base named.

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -602,3 +602,49 @@ removed, "cancer patients for Cancer Research UK" still blocks. The line is the
 _targeting basis_, not the advertiser's industry — which is why "audiences for a
 hearing aid brand" stays blocked: that is #164's own example wearing a client's
 hat.
+
+---
+
+## 2026-08-05 — A keyword list needs roles, not just terms (#157)
+
+**What went wrong.** A hearing-aids brief aimed at over-55s pulled in the travel
+research file. The gate in `src/historical_research.py` flattened each catalogue
+file's `topics` + `match_keywords` into one list of needles and admitted the file
+on any single hit. `affluent empty-nesters` was sitting in the travel file's
+`topics`, so one demographic overlap — nothing to do with the subject — was
+enough to admit 33 KB of travel research into a hearing-aids brief.
+
+**Why.** The bug was in the _vocabulary_, not the matcher. The word-boundary
+matching was already careful (`rail` does not fire on `email`); it matched
+exactly what it was asked to match. What was missing is that a research file's
+terms are not all of one kind: some say what the research is _about_, one said
+who was _surveyed_, and the gate treated them as equally sufficient. Tuning the
+matcher — fuzzier, stricter, a second required hit — would not have touched this.
+When a list-driven gate misfires, check whether the list is secretly holding two
+kinds of thing before you touch the matching logic.
+
+**How it was fixed.** A third frontmatter field, `audience_terms`, names the
+demographic explicitly. Admission now requires a hit in `topics`/`match_keywords`;
+`audience_terms` can never admit a file alone, but still ride along in
+`matched_on` after the subject terms, so a genuinely on-subject travel brief for
+over-55s shows the full overlap without the demographic having been the reason.
+Two properties were worth the extra lines:
+
+- **The demotion is not advisory.** A term listed under `audience_terms` is
+  stripped out of `topics`/`match_keywords` at load time wherever it also appears
+  there. Without that, a future file that leaves a demographic in both lists
+  re-opens the hole silently, and the frontmatter is authored by hand.
+- **Absent means unchanged.** A file with no `audience_terms` key keeps its whole
+  vocabulary as subject terms, so the catalogue's zero-code drop-in property
+  survives and no existing file needed editing to keep working.
+
+**The near-miss.** The first instinct was a central recogniser in code — age
+patterns, `affluent`, `empty-nester`, `ABC1` — applied across every file, on the
+theory that it also catches files nobody has authored yet. It would have
+over-blocked: `family holidays` is a genuine subject term that a demographic
+recogniser reads as a demographic, and the failure mode is silent (a research
+file quietly stops matching briefs it should). Per-file explicit declaration
+gives up automatic coverage of unwritten files in exchange for never guessing
+wrong about the file in front of it. For a catalogue of one, curated by hand,
+that is the right trade — and it is the same reason the segment gate in #164
+needed its guard pointed at real inputs rather than a plausible-looking list.

--- a/PRD-historical-research-catalogue.md
+++ b/PRD-historical-research-catalogue.md
@@ -4,9 +4,9 @@
 
 When a salesperson generates a brief, the tool draws on live, generic sources (web research, Google Trends, audience segments, formats, direct campaign history). What it **cannot** do today is reference the company's own **proprietary research** — the audience surveys and category studies that are the actual differentiator a media owner brings to a client conversation. That evidence currently lives in 53-slide decks that no salesperson opens mid-brief.
 
-This is a **proof-of-concept** to prove one specific thing, live, in a demo: **a catalogue of "historical research" files can be referenced by the agent flow and pulled through into the brief — automatically, only when relevant, and visibly to the salesperson.** We are starting with a single, real file — the *Immediate Media Travel Audience Research 2024/25* reference — and proving the end-to-end path. The value we are demonstrating is **grounded, cited, defensible proprietary evidence** appearing in the brief without anyone hunting for a deck.
+This is a **proof-of-concept** to prove one specific thing, live, in a demo: **a catalogue of "historical research" files can be referenced by the agent flow and pulled through into the brief — automatically, only when relevant, and visibly to the salesperson.** We are starting with a single, real file — the _Immediate Media Travel Audience Research 2024/25_ reference — and proving the end-to-end path. The value we are demonstrating is **grounded, cited, defensible proprietary evidence** appearing in the brief without anyone hunting for a deck.
 
-The bar for the POC is deliberately narrow: prove the *pull-through*, not build a research platform. Everything that makes it scale to N files is explicitly Phase 2.
+The bar for the POC is deliberately narrow: prove the _pull-through_, not build a research platform. Everything that makes it scale to N files is explicitly Phase 2.
 
 ## Solution
 
@@ -24,45 +24,52 @@ The proof is the contrast: a non-travel brief shows nothing; a travel brief make
 
 1. As a salesperson, I want the brief to automatically pull in our own proprietary research when it's relevant to the advertiser, so that I bring evidence a competitor can't.
 2. As a salesperson, I want that research to appear as a clearly-labelled card showing the source and its date, so that I can see exactly where the evidence came from and cite it with confidence.
-3. As a salesperson, I want the pulled findings to be tailored to *this* brief (e.g. cruise data for a cruise brand), so that they're immediately usable rather than a generic data dump.
+3. As a salesperson, I want the pulled findings to be tailored to _this_ brief (e.g. cruise data for a cruise brand), so that they're immediately usable rather than a generic data dump.
 4. As a salesperson running a brief with no relevant research, I want the brief to look completely normal (no empty or broken research box), so that the feature only ever adds value, never noise.
 5. As a salesperson, I want every figure quoted from the research to carry its audience and base (e.g. "n=334 cruise intenders, late-2024"), so that I don't accidentally over-claim a survey stat in front of a client.
 6. As the feature owner (Matt), I want to add a new research file by dropping a markdown file into a folder, so that growing the catalogue is zero-code.
 7. As the feature owner, I want the relevance gate to be deterministic and testable, so that "P&O fires, Nike doesn't" is a guaranteed, regression-guarded behaviour I can rely on in a live demo.
-8. As a demo audience member, I want to see the research card appear on a travel brief and *not* appear on a non-travel brief, so that I understand the system is selectively reasoning about relevance, not always bolting research on.
+8. As a demo audience member, I want to see the research card appear on a travel brief and _not_ appear on a non-travel brief, so that I understand the system is selectively reasoning about relevance, not always bolting research on.
 
 ## Implementation Decisions
 
 **Catalogue & storage**
+
 - Files live in `data/historical_research/*.md` — consistent with `data/` holding the pipeline's other file-backed sources.
 - Each file is markdown with YAML frontmatter. The travel file already has this shape; we add one field: **`match_keywords`** — a curated list of the single words a brief is likely to contain (e.g. `travel, holiday, cruise, flight, hotel, airline, tourism`). This de-risks matching against the verbose `topics` phrases.
 - Loading reuses the frontmatter-parsing pattern already in `src/web_search.py` (`re.match(r"^---\n(.+?)\n---\n(.+)", raw, re.DOTALL)` + `yaml.safe_load`). `pyyaml` is already a dependency.
 
 **Relevance gate (deterministic — the selection decision)**
+
 - New module `src/historical_research.py`. Interface shape: `get_relevant_research(topic, advertiser, client_brief) → {relevant, files/metadata, prompt_text}`.
 - Logic: concatenate `topic + advertiser + client_brief`, lowercase → for each file, test intersection against the flattened set of `topics` + `match_keywords` → **any single overlap includes the file**.
 - No LLM. No ranking or top-N — at N=1, every match is simply included.
+- **Revised by #157 (Aug 2026).** Not every term in a file's frontmatter is a reason to include it. A third field, **`audience_terms`**, names _who_ the research surveyed (`empty-nesters`, `older travellers`) as distinct from _what_ it is about. Only `topics` + `match_keywords` admit a file; `audience_terms` never admit on their own, and a term named as an audience term is stripped out of `topics`/`match_keywords` wherever it is also listed there, so a mis-authored file cannot re-open the hole. Where the brief shares the demographic as well as the subject, the audience terms still ride along in `matched_on`, after the subject terms. Files with no `audience_terms` key behave exactly as before. This closed the reported failure where a hearing-aids brief aimed at over-55s pulled in travel research on the strength of `affluent empty-nesters` alone, which had been sitting in `topics`.
 
 **Prompt injection (weaving)**
+
 - New `{historical_research}` placeholder in `USER_PROMPT_TEMPLATE`. On a match it carries the **whole file body** (verbatim — no chunking/extraction at N=1). On no-match it carries a fallback string (`"No historical research matched this brief."`).
 - SYSTEM_PROMPT gains a new `## Historical Research` output section instruction: when relevant research is present, produce 2–3 tailored findings bullets grounded in it; when it's the fallback, **omit the section entirely** (do not write "none found" into the prose).
 - SYSTEM_PROMPT gains one **minimal claim-use sentence**, matching the existing audience-segments citation-discipline house style: name the source audience, state fieldwork date, quote the base `n=` with any percentage, present as stated intention not behaviour, never sum multi-select percentages.
 
 **UI surfacing (the hero card)**
+
 - Single GPT-4o call, unchanged in count. The tailored bullets ride in the parsed `## Historical Research` section (reusing the frontend's existing `parseSections()` machinery — the same path "At a Glance" and "Key Recommendations" already use).
 - `generate_insights()` returns a `historical_research` object in the result dict: `{relevant: bool, ...}` and on a match `{title, organisation, fieldwork, total_respondents, matched_on}` — all pulled **verbatim from frontmatter** (deterministic, no hallucination risk).
 - The frontend composes the hero card from (metadata dict object) + (parsed prose bullets). Card renders **only** when `historical_research.relevant === true` — mirroring the conditional render already used for `campaign_history`.
 
 **Modules**
+
 - **New:** `src/historical_research.py` (loader + deterministic gate + prompt/fallback formatting).
 - **Modified:** `synthesiser` (call the gate, inject `{historical_research}`, return the dict object); `prompts` (new placeholder, `## Historical Research` section spec, claim-use sentence); frontend `/app` page (type + hero-card render, guarded on `relevant`).
 - **Data:** the travel `.md` file placed in `data/historical_research/`, with `match_keywords` added to its frontmatter.
 
 ## Testing Decisions
 
-**What makes a good test here:** the selection logic is a pure function over file metadata and brief text — no LLM, no network — so it's deterministic and exhaustively testable. The gate tests *are* the regression guard for the demo passing ("P&O fires, Nike doesn't"). LLM output (the tailored bullets and woven prose) and the UI card are **not** unit-tested — they're verified by eye in a dry run.
+**What makes a good test here:** the selection logic is a pure function over file metadata and brief text — no LLM, no network — so it's deterministic and exhaustively testable. The gate tests _are_ the regression guard for the demo passing ("P&O fires, Nike doesn't"). LLM output (the tailored bullets and woven prose) and the UI card are **not** unit-tested — they're verified by eye in a dry run.
 
 **Module to be tested — `src/historical_research.py`:**
+
 1. **Loader** — globs `data/historical_research/*.md`, parses frontmatter, returns metadata + body. Cover: valid file parses; `match_keywords` read correctly; empty/missing folder returns no files gracefully.
 2. **Relevance gate** (the money logic) — Cover: travel brief ("P&O Cruises" / "cruise campaign") → matches; non-travel brief ("Nike" / "running shoes") → no match; case-insensitivity; matching hits on `match_keywords` as well as `topics`; the `topic+advertiser+client_brief` concatenation (a keyword only in `client_brief` still matches).
 3. **No-match fallback & contract** — returns the fallback string and a `{relevant: false}` object when nothing matches; the `historical_research` dict key is always present with the correct shape in both states.
@@ -74,7 +81,7 @@ The proof is the contrast: a non-travel brief shows nothing; a travel brief make
 ## Out of Scope (explicitly deferred to Phase 2)
 
 - **LLM relevance classifier** — the semantic "Cunard → travel" leap. POC uses the deterministic keyword gate only.
-- **Multi-file ranking / top-N selection** — the loader globs many files, but no relevance *scoring* or "best N when several match." Moot at N=1; every match is included.
+- **Multi-file ranking / top-N selection** — the loader globs many files, but no relevance _scoring_ or "best N when several match." Moot at N=1; every match is included.
 - **Section-level extraction / chunking** — the whole file goes into the prompt; no per-section retrieval.
 - **Vector search** — the dormant ChromaDB layer is not revived for this; it stays Phase 2 alongside the editorial vector work.
 - **Upload / catalogue-management UI** — files are added by dropping a `.md` in the folder, not via any interface.
@@ -85,7 +92,7 @@ The proof is the contrast: a non-travel brief shows nothing; a travel brief make
 
 - **Demo script (the whole point):** two-brief contrast. (1) Non-travel brief — advertiser "Nike", topic "running shoes launch" → no Historical Research card, output looks normal. (2) Travel brief — advertiser "P&O Cruises", topic "cruise campaign for over-50s", KPI "Awareness" → card appears; the synthesis cites the survey's cruise data (23% consideration, n=334 intenders, P&O top at 38%, ocean/river/adults-only split). P&O chosen because §14 of the file gives the richest, most quotable cruise-specific evidence, so the woven output looks strikingly specific rather than generic.
 - **Why deterministic gate for a live demo:** the gate is keyword-based specifically so the demo has zero API dependency in the selection step — the salesperson controls the brief, and a travel keyword reliably fires the card every run.
-- **Why the panel is the hero:** invisible weaving alone can't be *seen* to work. The labelled card — with verbatim source metadata proving provenance and tailored bullets proving reasoning — is the visual that makes the pull-through concept legible to a non-technical room.
+- **Why the panel is the hero:** invisible weaving alone can't be _seen_ to work. The labelled card — with verbatim source metadata proving provenance and tailored bullets proving reasoning — is the visual that makes the pull-through concept legible to a non-technical room.
 - **Scaling story to tell stakeholders:** the catalogue, glob loader, and frontmatter gate are built to accept file #2 with zero code; the Phase 2 upgrades (LLM relevance, ranking, chunking, vector search) are the path from "one file, keyword gate" to "large research library, semantic retrieval."
 - Related in-flight work: this follows the same "real proprietary data into the brief" thread as `PRD-audience-segments.md` and `PRD-direct-campaign-history.md`, and reuses their citation-discipline and conditional-render patterns.
 

--- a/data/historical_research/travel_audience_research_2024_25.md
+++ b/data/historical_research/travel_audience_research_2024_25.md
@@ -52,7 +52,10 @@ match_keywords:
   - tours
   - destination
   - destinations
-# Who this research surveyed, as distinct from what it is about. These terms
+# Who this research speaks to, as distinct from what it is about. The survey
+# base is a general UK panel (n=1,589) with no age or affluence screen — these
+# are the audiences the file itself names as its best fit, not a sample
+# definition, so do not quote them as one. These terms
 # never admit the file on their own — a brief that shares only the demographic
 # gets no research (#157) — but they are reported alongside a subject match so
 # the overlap is visible for what it is.

--- a/data/historical_research/travel_audience_research_2024_25.md
+++ b/data/historical_research/travel_audience_research_2024_25.md
@@ -23,7 +23,6 @@ topics:
   - cultural travel
   - food and dining travel
   - special-interest holidays
-  - affluent empty-nesters
 match_keywords:
   - travel
   - travelling
@@ -53,6 +52,21 @@ match_keywords:
   - tours
   - destination
   - destinations
+# Who this research surveyed, as distinct from what it is about. These terms
+# never admit the file on their own — a brief that shares only the demographic
+# gets no research (#157) — but they are reported alongside a subject match so
+# the overlap is visible for what it is.
+audience_terms:
+  - empty-nester
+  - empty-nesters
+  - empty nester
+  - empty nesters
+  - affluent older audience
+  - affluent older audiences
+  - older traveller
+  - older travellers
+  - solo traveller
+  - solo travellers
 ---
 
 # Immediate Media Travel Audience Research 2024/25

--- a/src/historical_research.py
+++ b/src/historical_research.py
@@ -25,7 +25,13 @@ def load_catalogue(catalogue_dir=None):
     skipped. A missing/empty folder yields an empty list (graceful absence).
 
     Each returned dict carries the parsed ``meta`` frontmatter, the verbatim
-    ``body``, and the flattened ``topics`` + ``match_keywords`` used by the gate.
+    ``body``, and the file's vocabulary split by role: ``topics`` +
+    ``match_keywords`` say what the research is about, ``audience_terms`` say
+    who was surveyed. Only the first kind can admit a file (see
+    ``get_relevant_research``), so a term named as an audience term is stripped
+    out of ``topics``/``match_keywords`` wherever it also appears there — a
+    mis-authored file cannot smuggle a demographic back in as a subject.
+    ``meta`` keeps the frontmatter verbatim either way.
     """
     if catalogue_dir is None:
         catalogue_dir = CATALOGUE_DIR
@@ -45,16 +51,30 @@ def load_catalogue(catalogue_dir=None):
 
         topics = meta.get("topics") or []
         match_keywords = meta.get("match_keywords") or []
+        audience_terms = meta.get("audience_terms") or []
+
+        demographic = set(_normalise(t) for t in audience_terms)
+        demographic.discard("")
+
+        def subject_only(terms):
+            return [t for t in terms if _normalise(t) not in demographic]
 
         files.append({
             "meta": meta,
             "body": body,
-            "topics": list(topics),
-            "match_keywords": list(match_keywords),
+            "topics": subject_only(topics),
+            "match_keywords": subject_only(match_keywords),
+            "audience_terms": list(audience_terms),
             "file": os.path.basename(path),
         })
 
     return files
+
+
+def _normalise(term):
+    # type: (str) -> str
+    """Lowercase and trim a catalogue term so the two roles compare like for like."""
+    return (term or "").strip().lower()
 
 
 def _find_matches(brief_text, needles):
@@ -67,7 +87,7 @@ def _find_matches(brief_text, needles):
     """
     hits = []
     for needle in needles:
-        needle = (needle or "").strip().lower()
+        needle = _normalise(needle)
         if not needle or needle in hits:
             continue  # de-dupe: a term can sit in both topics and match_keywords
         pattern = r"\b" + re.escape(needle) + r"\b"
@@ -81,8 +101,16 @@ def get_relevant_research(topic, advertiser, client_brief, catalogue_dir=None):
     """Deterministic relevance gate over the research catalogue.
 
     Concatenates ``topic + advertiser + client_brief`` (lowercased) and tests it
-    against each file's flattened ``topics`` + ``match_keywords``. Any single
-    overlap includes the file. No LLM, no network — reproducible every run.
+    against each file's vocabulary. No LLM, no network — reproducible every run.
+
+    Admission turns on subject relevance alone: a file is included only when the
+    brief overlaps its ``topics``/``match_keywords``, which describe what the
+    research is *about*. Its ``audience_terms`` — who was surveyed — can never
+    admit a file on their own, because sharing a demographic is not a reason to
+    include research on an unrelated subject (a hearing-aids brief aimed at
+    over-55s was pulling in travel research; #157). Where the brief shares the
+    demographic *as well*, those terms still ride along in ``matched_on``, so
+    the hero card can show the full overlap without it having been the reason.
 
     Always returns a dict with ``relevant`` and ``prompt_text``. On a match it
     also carries verbatim frontmatter metadata (``title``, ``organisation``,
@@ -91,29 +119,36 @@ def get_relevant_research(topic, advertiser, client_brief, catalogue_dir=None):
     brief_text = " ".join([topic or "", advertiser or "", client_brief or ""]).lower()
 
     for f in load_catalogue(catalogue_dir):
-        needles = f["topics"] + f["match_keywords"]
-        matched_on = _find_matches(brief_text, needles)
-        if matched_on:
-            meta = f["meta"]
-            start = str(meta.get("fieldwork_start", "") or "")
-            end = str(meta.get("fieldwork_end", "") or "")
-            if start and end:
-                fieldwork = "%s to %s" % (start, end)
-            else:
-                fieldwork = start or end
-            return {
-                "relevant": True,
-                "prompt_text": f["body"],
-                # Identifies the matched catalogue file so a downstream consumer
-                # (the deck) can re-read the same body from load_catalogue()
-                # rather than the body being shipped to the client and back.
-                "file": f["file"],
-                "title": meta.get("title", ""),
-                "organisation": meta.get("organisation", ""),
-                "fieldwork": fieldwork,
-                "total_respondents": meta.get("total_respondents"),
-                "matched_on": matched_on,
-            }
+        subject_hits = _find_matches(brief_text, f["topics"] + f["match_keywords"])
+        if not subject_hits:
+            continue  # no subject overlap — a shared demographic cannot stand in
+
+        audience_hits = [
+            hit for hit in _find_matches(brief_text, f["audience_terms"])
+            if hit not in subject_hits
+        ]
+        matched_on = subject_hits + audience_hits
+
+        meta = f["meta"]
+        start = str(meta.get("fieldwork_start", "") or "")
+        end = str(meta.get("fieldwork_end", "") or "")
+        if start and end:
+            fieldwork = "%s to %s" % (start, end)
+        else:
+            fieldwork = start or end
+        return {
+            "relevant": True,
+            "prompt_text": f["body"],
+            # Identifies the matched catalogue file so a downstream consumer
+            # (the deck) can re-read the same body from load_catalogue()
+            # rather than the body being shipped to the client and back.
+            "file": f["file"],
+            "title": meta.get("title", ""),
+            "organisation": meta.get("organisation", ""),
+            "fieldwork": fieldwork,
+            "total_respondents": meta.get("total_respondents"),
+            "matched_on": matched_on,
+        }
 
     return {
         "relevant": False,

--- a/src/historical_research.py
+++ b/src/historical_research.py
@@ -15,6 +15,54 @@ CATALOGUE_DIR = os.path.join(os.path.dirname(__file__), "..", "data", "historica
 FALLBACK_TEXT = "No historical research matched this brief."
 
 
+def _normalise(term):
+    # type: (str) -> str
+    """Lowercase and trim a catalogue term so the two roles compare like for like."""
+    return (term or "").strip().lower()
+
+
+def _subject_terms(terms, audience_terms):
+    # type: (list, list) -> list
+    """Drop from ``terms`` anything the file also names as an audience term.
+
+    Naming a term under ``audience_terms`` demotes it wherever else it appears,
+    so a hand-authored file that leaves a demographic in ``topics`` as well
+    cannot quietly re-open the hole #157 closed.
+    """
+    demoted = set(_normalise(t) for t in audience_terms)
+    demoted.discard("")
+    return [t for t in terms if _normalise(t) not in demoted]
+
+
+def _find_matches(brief_text, needles, exclude=()):
+    # type: (str, list, tuple) -> list
+    """Return the needles that appear in ``brief_text`` as whole words.
+
+    Whole-word matching (not bare substring) keeps the gate honest: the keyword
+    "rail" matches "rail" but not "email", and the phrase "city breaks" matches
+    only when both words appear together. Deterministic — no LLM.
+
+    The guard is a pair of lookarounds rather than ``\\b`` because a catalogue
+    term may legitimately end in punctuation: ``\\b55\\+\\b`` can never match
+    "55+", since ``\\b`` after the "+" demands an adjacent word character. A
+    term that silently never matches is the worst failure mode for a hand-
+    authored list, so the boundary is defined by what sits *outside* the needle.
+
+    ``exclude`` names hits already reported by an earlier call, so a term
+    carrying two roles is not listed twice.
+    """
+    hits = []
+    for needle in needles:
+        needle = _normalise(needle)
+        # De-dupe: a term can sit in both topics and match_keywords.
+        if not needle or needle in hits or needle in exclude:
+            continue
+        pattern = r"(?<!\w)" + re.escape(needle) + r"(?!\w)"
+        if re.search(pattern, brief_text):
+            hits.append(needle)
+    return hits
+
+
 def load_catalogue(catalogue_dir=None):
     # type: (str) -> list
     """Glob-load every research file in the catalogue.
@@ -27,7 +75,7 @@ def load_catalogue(catalogue_dir=None):
     Each returned dict carries the parsed ``meta`` frontmatter, the verbatim
     ``body``, and the file's vocabulary split by role: ``topics`` +
     ``match_keywords`` say what the research is about, ``audience_terms`` say
-    who was surveyed. Only the first kind can admit a file (see
+    who it speaks to. Only the first kind can admit a file (see
     ``get_relevant_research``), so a term named as an audience term is stripped
     out of ``topics``/``match_keywords`` wherever it also appears there — a
     mis-authored file cannot smuggle a demographic back in as a subject.
@@ -53,47 +101,16 @@ def load_catalogue(catalogue_dir=None):
         match_keywords = meta.get("match_keywords") or []
         audience_terms = meta.get("audience_terms") or []
 
-        demographic = set(_normalise(t) for t in audience_terms)
-        demographic.discard("")
-
-        def subject_only(terms):
-            return [t for t in terms if _normalise(t) not in demographic]
-
         files.append({
             "meta": meta,
             "body": body,
-            "topics": subject_only(topics),
-            "match_keywords": subject_only(match_keywords),
+            "topics": _subject_terms(topics, audience_terms),
+            "match_keywords": _subject_terms(match_keywords, audience_terms),
             "audience_terms": list(audience_terms),
             "file": os.path.basename(path),
         })
 
     return files
-
-
-def _normalise(term):
-    # type: (str) -> str
-    """Lowercase and trim a catalogue term so the two roles compare like for like."""
-    return (term or "").strip().lower()
-
-
-def _find_matches(brief_text, needles):
-    # type: (str, list) -> list
-    """Return the needles that appear in ``brief_text`` on a word boundary.
-
-    Word-boundary matching (not bare substring) keeps the gate honest: the
-    keyword "rail" matches "rail" but not "email", and the phrase "city breaks"
-    matches only when both words appear together. Deterministic — no LLM.
-    """
-    hits = []
-    for needle in needles:
-        needle = _normalise(needle)
-        if not needle or needle in hits:
-            continue  # de-dupe: a term can sit in both topics and match_keywords
-        pattern = r"\b" + re.escape(needle) + r"\b"
-        if re.search(pattern, brief_text):
-            hits.append(needle)
-    return hits
 
 
 def get_relevant_research(topic, advertiser, client_brief, catalogue_dir=None):
@@ -105,12 +122,15 @@ def get_relevant_research(topic, advertiser, client_brief, catalogue_dir=None):
 
     Admission turns on subject relevance alone: a file is included only when the
     brief overlaps its ``topics``/``match_keywords``, which describe what the
-    research is *about*. Its ``audience_terms`` — who was surveyed — can never
+    research is *about*. Its ``audience_terms`` — who it speaks to — can never
     admit a file on their own, because sharing a demographic is not a reason to
     include research on an unrelated subject (a hearing-aids brief aimed at
     over-55s was pulling in travel research; #157). Where the brief shares the
-    demographic *as well*, those terms still ride along in ``matched_on``, so
-    the hero card can show the full overlap without it having been the reason.
+    demographic *as well*, those terms still ride along in ``matched_on``,
+    ordered after the subject hits, so the hero card can show the full overlap
+    without the demographic having been the reason. The two roles flatten into
+    one list because that is the shape the card already renders; ordering is the
+    contract, and callers needing the split should read the file's frontmatter.
 
     Always returns a dict with ``relevant`` and ``prompt_text``. On a match it
     also carries verbatim frontmatter metadata (``title``, ``organisation``,
@@ -123,10 +143,7 @@ def get_relevant_research(topic, advertiser, client_brief, catalogue_dir=None):
         if not subject_hits:
             continue  # no subject overlap — a shared demographic cannot stand in
 
-        audience_hits = [
-            hit for hit in _find_matches(brief_text, f["audience_terms"])
-            if hit not in subject_hits
-        ]
+        audience_hits = _find_matches(brief_text, f["audience_terms"], exclude=subject_hits)
         matched_on = subject_hits + audience_hits
 
         meta = f["meta"]

--- a/tests/test_historical_research.py
+++ b/tests/test_historical_research.py
@@ -419,6 +419,48 @@ def test_loader_defaults_audience_terms_to_empty(catalogue_dir_no_match_keywords
     assert files[0]["audience_terms"] == []
 
 
+def test_demographic_only_brief_omits_the_section_end_to_end(catalogue_dir):
+    """The no-match path feeds the omission machinery, not just a False flag.
+
+    An empty body is what makes the deck drop its Historical Insights slide, so
+    a brief that now stops matching has to reach that state, not merely report
+    ``relevant: False``.
+    """
+    result = get_relevant_research(
+        "hearing aids", "Boots Hearingcare", "Reach affluent empty-nesters",
+        catalogue_dir=catalogue_dir,
+    )
+    assert load_research_body(result, catalogue_dir=catalogue_dir) == ""
+
+
+def test_a_term_ending_in_punctuation_is_not_a_dead_term(tmp_path):
+    """`\\b55\\+\\b` can never match "55+" — a silently dead hand-authored term.
+
+    #157's own wording is a 55+ audience, so the trap is one an author of this
+    frontmatter would walk straight into. The boundary is defined by what sits
+    outside the needle instead.
+    """
+    d = tmp_path / "historical_research"
+    d.mkdir()
+    (d / "ages.md").write_text(
+        '---\ntitle: "Age Bands Study"\ntopics:\n  - retirement planning\n'
+        'audience_terms:\n  - 55+\n---\n\n# Age Bands Study\n\nBody.\n'
+    )
+    result = get_relevant_research(
+        "retirement planning", "Acme", "Audience is 55+", catalogue_dir=str(d),
+    )
+    assert result["relevant"] is True
+    assert "55+" in result["matched_on"]
+
+
+def test_whole_word_guard_still_rejects_a_substring_hit(catalogue_dir):
+    """The lookaround boundary must not loosen the rail/email guarantee."""
+    result = get_relevant_research(
+        "email marketing", "Acme", "", catalogue_dir=catalogue_dir,
+    )
+    assert result["relevant"] is False
+
+
 def test_real_catalogue_hearing_aids_brief_gets_no_travel_research():
     """The shipped catalogue, against the brief Abel actually reported."""
     result = get_relevant_research(

--- a/tests/test_historical_research.py
+++ b/tests/test_historical_research.py
@@ -27,6 +27,10 @@ match_keywords:
   - cruise
   - flight
   - hotel
+audience_terms:
+  - affluent empty-nesters
+  - empty nesters
+  - over-55s
 ---
 
 # Immediate Media Travel Audience Research 2024/25
@@ -311,6 +315,125 @@ def test_gate_none_inputs_do_not_crash(catalogue_dir):
     result = get_relevant_research(None, None, None, catalogue_dir=catalogue_dir)
     assert result["relevant"] is False
     assert result["prompt_text"] == "No historical research matched this brief."
+
+
+# --- Subject relevance vs shared demographic (#157) ------------------------
+#
+# A research file's vocabulary is not all of one kind. Its topics and
+# match_keywords describe what the research is ABOUT; its audience_terms
+# describe WHO was surveyed. Only the first kind may admit a file — otherwise a
+# hearing-aids brief aimed at over-55s pulls in travel research on the strength
+# of the demographic alone, which is what Abel hit in the August 2026 QA round.
+
+# A file whose audience descriptors are (wrongly) left in `topics` as well as in
+# `audience_terms`. Listing a term as an audience term must demote it wherever
+# else it appears, so a mis-authored file cannot re-open the hole.
+FIXTURE_DEMOGRAPHIC_IN_TOPICS = """\
+---
+title: "Later Life Leisure Study 2025"
+organisation: "TestOrg"
+fieldwork_start: "2025-02-01"
+fieldwork_end: "2025-02-28"
+total_respondents: 900
+topics:
+  - garden centres
+  - affluent empty-nesters
+match_keywords:
+  - gardening
+audience_terms:
+  - affluent empty-nesters
+---
+
+# Later Life Leisure Study 2025
+
+Survey of 900 adults aged 55 and over.
+"""
+
+
+@pytest.fixture()
+def catalogue_dir_demographic_in_topics(tmp_path):
+    d = tmp_path / "historical_research"
+    d.mkdir()
+    (d / "leisure.md").write_text(FIXTURE_DEMOGRAPHIC_IN_TOPICS)
+    return str(d)
+
+
+def test_shared_demographic_alone_does_not_admit_research(catalogue_dir):
+    """Abel's report: a hearing-aids brief must not pull in travel research."""
+    result = get_relevant_research(
+        "hearing aids", "Boots Hearingcare",
+        "Reach affluent empty-nesters, over-55s, in the market for hearing aids",
+        catalogue_dir=catalogue_dir,
+    )
+    assert result["relevant"] is False
+    assert result["prompt_text"] == "No historical research matched this brief."
+    assert "title" not in result
+
+
+def test_subject_match_still_admits_when_the_demographic_is_shared_too(catalogue_dir):
+    """The demographic must not disqualify research that is genuinely on-subject."""
+    result = get_relevant_research(
+        "river cruises", "Riviera Travel",
+        "Reach affluent empty-nesters, over-55s, planning a cruise",
+        catalogue_dir=catalogue_dir,
+    )
+    assert result["relevant"] is True
+    # Both kinds of term are reported, subject first, so the hero card can say
+    # what actually earned the match rather than only who was surveyed.
+    assert result["matched_on"][0] in ("cruises", "travel", "cruise")
+    assert "affluent empty-nesters" in result["matched_on"]
+
+
+def test_subject_match_alone_still_admits(catalogue_dir):
+    """No demographic overlap at all is still a match on subject."""
+    result = get_relevant_research(
+        "city breaks push", "SomeBrand", "Reach students",
+        catalogue_dir=catalogue_dir,
+    )
+    assert result["relevant"] is True
+    assert result["matched_on"] == ["city breaks"]
+
+
+def test_audience_term_is_demoted_even_where_topics_repeats_it(
+    catalogue_dir_demographic_in_topics,
+):
+    result = get_relevant_research(
+        "hearing aids", "Boots Hearingcare", "Reach affluent empty-nesters",
+        catalogue_dir=catalogue_dir_demographic_in_topics,
+    )
+    assert result["relevant"] is False
+
+
+def test_loader_exposes_audience_terms(catalogue_dir):
+    files = load_catalogue(catalogue_dir)
+    assert files[0]["audience_terms"] == [
+        "affluent empty-nesters", "empty nesters", "over-55s",
+    ]
+    # ...and they are kept out of the subject vocabulary.
+    assert "affluent empty-nesters" not in files[0]["topics"]
+
+
+def test_loader_defaults_audience_terms_to_empty(catalogue_dir_no_match_keywords):
+    """A file predating the field keeps its whole vocabulary as subject terms."""
+    files = load_catalogue(catalogue_dir_no_match_keywords)
+    assert files[0]["audience_terms"] == []
+
+
+def test_real_catalogue_hearing_aids_brief_gets_no_travel_research():
+    """The shipped catalogue, against the brief Abel actually reported."""
+    result = get_relevant_research(
+        "hearing aids", "Boots Hearingcare",
+        "Audience is affluent empty-nesters, over-55s, with mild hearing loss",
+    )
+    assert result["relevant"] is False
+
+
+def test_real_catalogue_still_admits_an_over_55s_travel_brief():
+    result = get_relevant_research(
+        "cruises", "P&O Cruises", "Audience is affluent empty-nesters, over-55s",
+    )
+    assert result["relevant"] is True
+    assert result["total_respondents"] == 1589
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #157. Part of #154 (QA round, August 2026).

## The bug

The gate flattened each research file's `topics` + `match_keywords` into one list of needles and admitted the file on **any single hit**. The travel file had `affluent empty-nesters` sitting in its `topics`, so one demographic overlap — nothing to do with the subject — admitted 33 KB of travel research.

> "A hearing-aids brief surfaced travel research, seemingly just because the audience was 55+." — Abel

**The fault was in the vocabulary, not the matcher.** The whole-word matching was already careful — `rail` correctly does not fire on `email` — and it matched exactly what it was asked to match. What was missing is that a file's terms are not all of one kind: some say what the research is *about*, one said who it *speaks to*, and the gate treated them as equally sufficient. Tuning the matcher (fuzzier, stricter, a second required hit) would not have touched this.

## The change

A third frontmatter field, `audience_terms`, names the demographic explicitly. Admission requires a hit in `topics`/`match_keywords`; audience terms never admit a file alone, but still ride along in `matched_on` **after** the subject hits, so an on-subject travel brief for over-55s shows the full overlap without the demographic having been the reason.

Two properties are load-bearing:

1. **The demotion is not advisory.** A term listed under `audience_terms` is stripped from `topics`/`match_keywords` at load time wherever it also appears there. This frontmatter is authored by hand; without that, a future file that leaves a demographic in both lists silently re-opens the hole.
2. **Absent means unchanged.** A file with no `audience_terms` key keeps its whole vocabulary as subject terms, so the catalogue's zero-code drop-in property survives and no other file needed editing.

## The approach I rejected

A central recogniser in code — age patterns, `affluent`, `empty-nester`, `ABC1` — applied across every file, on the theory that it also covers files nobody has authored yet. It over-blocks: `family holidays` is a genuine subject term a demographic recogniser reads as a demographic, and the failure is **silent** — a research file quietly stops matching briefs it should. Per-file declaration gives up automatic coverage of unwritten files in exchange for never guessing wrong about the file in front of it. Same reasoning as #164's guard needing real inputs rather than a plausible-looking list.

## Acceptance criteria

- [x] Subject relevance is required for a research file to be admitted — a demographic match alone is not sufficient
- [x] A hearing-aids brief with a 55+ audience does not surface travel research
- [x] Genuinely relevant research is still admitted, including where it also happens to share a demographic
- [x] Where nothing relevant matches, the brief omits the section rather than padding it

Verified against the real catalogue:

| Brief | Admitted | `matched_on` |
|---|---|---|
| cruises / P&O, affluent empty-nesters + older travellers | yes | `cruises`, `empty-nesters`, `older travellers` |
| hearing aids / Boots Hearingcare, affluent empty-nesters, over-55s | **no** | — |
| city breaks / Eurostar | yes | `city breaks` |
| running shoes / Nike | no | — |

## Worth a reviewer's eye

**A latent trap the review caught.** The whole-word guard used `\b`, which can never match a term ending in punctuation: `\b55\+\b` demands a word character immediately after the `+`, so the term `55+` is **silently dead** — nothing errors, no test fails, it just never fires. Since this ticket's own wording is "a 55+ audience", the next author of this frontmatter would have walked straight into it. The boundary is now defined by what sits *outside* the needle, `(?<!\w)...(?!\w)`, which matches `55+` and still refuses `rail` inside `email`. Both directions are pinned by tests.

**A claim-discipline fix.** My first version of the frontmatter comment called `audience_terms` "who this research surveyed". It is not — the base is a general UK panel of 1,589 with no age or affluence screen, and the terms come from the file's own "best fit" passages. In a product selling defensible sourcing, a comment that turns positioning into a sample definition is the over-claim the prompt's citation rules exist to prevent. Reworded, with the real base named.

**A scope call.** `matched_on` stays one flat list, subject hits first, rather than splitting the two roles in the payload. That is the shape `HistoricalResearchCard` already renders, and naming a per-term selection reason is #163's job — next in #154's list, on these same surfaces.

**Not fixed, pre-existing:** subject homonyms can still admit wrongly — `"tour of our hearing clinics"` matches the travel keyword `tour`. Out of scope here; worth a ticket if it recurs.

## Tests

TDD, red first. 11 new tests: demographic-only does not admit, subject match still admits when the demographic is shared too, subject-only match, the demotion holding when `topics` repeats an audience term, loader exposure and defaulting, both real-catalogue directions, the `55+` dead-term regression, the rail/email guarantee under the new boundary, and one tying the no-match path to the omission machinery (an empty research body is what makes the deck drop its slide, so `relevant: False` alone was not enough to assert).

564 Python + 39 frontend tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)