### PR TITLE
Reshape the landing page's data-source claims (#175)

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -1132,3 +1132,39 @@ strip it would have been the expensive way to achieve exactly the same screen.
 **Transferable point:** parse into your shape, don't cast onto it. It buys
 forwards _and_ backwards compatibility from the same few lines, and it is the
 difference between a schema change being a migration and being a no-op.
+
+---
+
+## 7 Aug 2026 — `hyphens: auto` is not a wrapping strategy you can rely on (#175)
+
+**What went wrong:** the landing page's data-source cards were replaced, and one
+new title — "Format Recommendations" — ran out of its card on a phone. The grid
+is `grid-cols-2` at every width, so at a 390px viewport a card offers about 98px
+of text, while "Recommendations" set in 18px Montserrat measures 179px. No font
+size the heading could plausibly take fits it: even at 14px it needs 139px.
+
+**What did not fix it:** `hyphens-auto`. Chrome, on macOS, with `lang="en"` set
+on `<html>`, left the word overflowing its box untouched — measured, not
+assumed: `scrollWidth` 179 against `clientWidth` 98. Adding `break-words`
+stopped the overflow but broke mid-syllable with no hyphen at all, rendering
+"Recomme / ndations" on a marketing page.
+
+**The fix:** soft hyphens (`­`) in the title itself, in
+`frontend/lib/landingContent.ts`. They are invisible at desktop width, where the
+title fits on one line, and mark where the word may break when it cannot. Since
+the character is invisible, a `plainTitle()` helper strips it so tests can
+assert the real name, and a test caps every unbreakable run in a title at ten
+characters — derived from the measured 98px box, where "Historical" (89px) is
+the widest real word that fits.
+
+**How it was caught:** by measuring in a real browser at a real width, not by
+reading the JSX. `npm run build` passes either way, and the repo has no DOM
+harness, so nothing in the test suite could have seen it. Rendering the page in
+a 390px iframe and reading `scrollWidth` vs `clientWidth` per card is the cheap
+version of the check.
+
+**Transferable point:** the same one as
+[[overlapping-deck-text-the-renderer-not-the-file]] — a text box has a fixed
+capacity, and whether a string fits is a question about a specific string in a
+specific box. Measure it; do not delegate it to a CSS property that degrades
+silently.

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,6 +7,7 @@ import StatusDot from "@/components/StatusDot";
 import SectionHeading from "@/components/SectionHeading";
 import Link from "next/link";
 import { useAnalytics } from "@/components/AnalyticsProvider";
+import { DATA_SOURCES, DATA_SOURCES_HEADING } from "@/lib/landingContent";
 
 export default function LandingPage() {
   const { track } = useAnalytics();
@@ -152,11 +153,11 @@ export default function LandingPage() {
                 </svg>
               </div>
               <h3 className="font-headline text-2xl font-bold mb-4 relative z-10">
-                Audience & Trends
+                Audience Behaviour
               </h3>
               <p className="text-slate-400 leading-relaxed relative z-10">
-                Behavioural data and real-time Google Trends signals to identify
-                when and how your audience is most engaged.
+                First-party behavioural data to identify which segments to
+                reach, at what scale, and when they are most engaged.
               </p>
             </div>
           </div>
@@ -169,45 +170,30 @@ export default function LandingPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-24 items-center">
             <div>
               <h2 className="text-4xl md:text-5xl font-headline font-bold leading-tight mb-6">
-                Four data sources.{" "}
-                <span className="text-accent-cyan">One unified strategy.</span>
+                {DATA_SOURCES_HEADING}
               </h2>
               <p className="text-xl text-slate-400 leading-relaxed">
-                Every Prism Plan synthesises editorial expertise, brand
-                intelligence, audience behaviour, and live trend data into a
+                Every Prism Plan synthesises brand intelligence, audience
+                behaviour, format benchmarks, and campaign history into a
                 single, actionable advertising recommendation.
               </p>
             </div>
 
             {/* Data source cards */}
             <div className="grid grid-cols-2 gap-8">
-              {[
-                {
-                  title: "Editorial Transcripts",
-                  description:
-                    "In-depth editor interviews surfacing themes, angles, and audience sentiment.",
-                },
-                {
-                  title: "Brand Research",
-                  description:
-                    "Automated web research into advertiser positioning, campaigns, and competitors.",
-                },
-                {
-                  title: "Audience Segments & Reach",
-                  description:
-                    "The most relevant targetable segments per platform, each with real reach.",
-                },
-                {
-                  title: "Google Trends",
-                  description:
-                    "Real-time search interest, related queries, and multi-timeframe analysis.",
-                },
-              ].map((source) => (
+              {DATA_SOURCES.map((source) => (
                 <div
                   key={source.title}
                   className="p-6 bg-surface-container-low rounded-xl border border-white/5 hover:border-accent-cyan/20 transition-all duration-300"
                 >
-                  <h4 className="font-headline font-bold text-lg mb-2">
+                  {/*
+                   * The grid stays two-up at every width, so a card is ~98px
+                   * of content on a phone — narrower than the single word
+                   * "Recommendations". The titles carry soft hyphens for that
+                   * (see `landingContent.ts`); break-words is the backstop for
+                   * a narrower phone still, where even a syllable overruns.
+                   */}
+                  <h4 className="font-headline font-bold text-lg mb-2 break-words">
                     {source.title}
                   </h4>
                   <p className="text-slate-500 text-sm leading-relaxed">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -187,11 +187,10 @@ export default function LandingPage() {
                   className="p-6 bg-surface-container-low rounded-xl border border-white/5 hover:border-accent-cyan/20 transition-all duration-300"
                 >
                   {/*
-                   * The grid stays two-up at every width, so a card is ~98px
-                   * of content on a phone — narrower than the single word
-                   * "Recommendations". The titles carry soft hyphens for that
-                   * (see `landingContent.ts`); break-words is the backstop for
-                   * a narrower phone still, where even a syllable overruns.
+                   * Titles carry soft hyphens because this grid stays two-up on
+                   * a phone — see `SHY` in `lib/landingContent.ts`. break-words
+                   * is the backstop for a narrower phone still, where even a
+                   * syllable overruns.
                    */}
                   <h4 className="font-headline font-bold text-lg mb-2 break-words">
                     {source.title}

--- a/frontend/lib/landingContent.test.ts
+++ b/frontend/lib/landingContent.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+import {
+  DATA_SOURCES,
+  DATA_SOURCES_HEADING,
+  plainTitle,
+} from "./landingContent";
+
+const landingPage = () =>
+  readFileSync(new URL("../app/page.tsx", import.meta.url), "utf8");
+
+describe("the data sources the landing page advertises (#175)", () => {
+  it("names four sources, because the heading counts them", () => {
+    expect(DATA_SOURCES).toHaveLength(4);
+    expect(DATA_SOURCES_HEADING).toBe("Four data sources.");
+  });
+
+  it("advertises only sources the product ships today", () => {
+    expect(DATA_SOURCES.map((source) => plainTitle(source.title))).toEqual([
+      "Brand Research",
+      "Audience Segments & Reach",
+      "Format Recommendations",
+      "Campaign History & Historical Research",
+    ]);
+  });
+
+  it("leaves the two surviving cards untouched", () => {
+    const brandResearch = DATA_SOURCES.find(
+      (source) => plainTitle(source.title) === "Brand Research",
+    );
+    const segments = DATA_SOURCES.find(
+      (source) => plainTitle(source.title) === "Audience Segments & Reach",
+    );
+    expect(brandResearch?.description).toBe(
+      "Automated web research into advertiser positioning, campaigns, and competitors.",
+    );
+    expect(segments?.description).toBe(
+      "The most relevant targetable segments per platform, each with real reach.",
+    );
+  });
+
+  /**
+   * The grid is two-up at every width, so on a phone a card holds about 98px
+   * of text — ten characters of 18px Montserrat ("Historical", measured at
+   * 89px, is the widest real word and fits). A longer unbreakable run leaves
+   * its card, so it has to arrive carrying soft hyphens.
+   */
+  it("gives every title a break opportunity inside the mobile card", () => {
+    const MOBILE_CARD_CHARS = 10;
+    for (const source of DATA_SOURCES) {
+      const runs = source.title.split(/[\s­]+/).filter(Boolean);
+      for (const run of runs) {
+        expect(
+          run.length,
+          `"${run}" in "${plainTitle(source.title)}" cannot break`,
+        ).toBeLessThanOrEqual(MOBILE_CARD_CHARS);
+      }
+    }
+  });
+
+  /**
+   * The cards sit in a two-up grid, so a description that runs long pushes its
+   * card taller than the one beside it. The existing copy is the budget: the
+   * two new cards may not be dramatically longer than the longest survivor.
+   */
+  it("keeps each description to one sentence of card-sized copy", () => {
+    for (const source of DATA_SOURCES) {
+      expect(source.description.length).toBeLessThanOrEqual(120);
+      expect(source.description.trim().split(". ")).toHaveLength(1);
+      expect(source.description.trim().endsWith(".")).toBe(true);
+    }
+  });
+});
+
+/**
+ * Pinned by reading the page source, in the spirit of the #161 navigation pin:
+ * the heading and the feature cards are JSX literals in a repo with no DOM
+ * harness, so reading them is the only way to stop a removed product being
+ * re-advertised by a later edit.
+ */
+describe("the landing page does not advertise a removed feature (#175)", () => {
+  it("makes no mention of Google Trends", () => {
+    expect(landingPage()).not.toMatch(/google trends/i);
+    expect(landingPage()).not.toMatch(/trend data/i);
+  });
+
+  it("does not promise editorial transcripts", () => {
+    expect(landingPage()).not.toMatch(/editorial transcripts/i);
+  });
+
+  it("drops the unified strategy claim", () => {
+    expect(landingPage()).not.toMatch(/unified strategy/i);
+  });
+
+  it("renders its data source cards from the tested list", () => {
+    const source = landingPage();
+    expect(source).toMatch(/DATA_SOURCES/);
+    expect(source).toMatch(/DATA_SOURCES_HEADING/);
+  });
+});

--- a/frontend/lib/landingContent.test.ts
+++ b/frontend/lib/landingContent.test.ts
@@ -4,6 +4,7 @@ import {
   DATA_SOURCES,
   DATA_SOURCES_HEADING,
   plainTitle,
+  titleRuns,
 } from "./landingContent";
 
 const landingPage = () =>
@@ -40,20 +41,33 @@ describe("the data sources the landing page advertises (#175)", () => {
   });
 
   /**
-   * The grid is two-up at every width, so on a phone a card holds about 98px
-   * of text — ten characters of 18px Montserrat ("Historical", measured at
-   * 89px, is the widest real word and fits). A longer unbreakable run leaves
-   * its card, so it has to arrive carrying soft hyphens.
+   * The grid is two-up at every width, so on a phone a card holds about 98px of
+   * text, and a run that cannot break inside it leaves the card.
+   *
+   * This cap is a **heuristic, not a measurement**, and deliberately unlike
+   * `tests/test_tile_fit.py`, which measures real Barlow advance widths because
+   * the question there is whether a specific string fits a specific box. There
+   * is no font-metrics harness on this side of the repo, and adding one to
+   * guard four marketing titles would cost more than it protects. So: a
+   * character count is not monotonic in a proportional face — "Wwwwwwwwww" is
+   * far wider than "Historical" at the same ten characters — and this test can
+   * be passed by a string that still overflows.
+   *
+   * What it is worth is the case it was written for. The cap comes from the
+   * browser measurement in LESSONS_LEARNED.md: at 390px the card offers 98px,
+   * where "Historical" (10 characters, 89px of 18px Montserrat) is the widest
+   * real word that fits and "Recommendations" (15, 179px) is the one that did
+   * not. A title arriving without break opportunities is the regression; a
+   * pathological all-W title is not a thing marketing copy does.
    */
   it("gives every title a break opportunity inside the mobile card", () => {
-    const MOBILE_CARD_CHARS = 10;
+    const WIDEST_FITTING_TITLE_RUN = "Historical".length;
     for (const source of DATA_SOURCES) {
-      const runs = source.title.split(/[\s­]+/).filter(Boolean);
-      for (const run of runs) {
+      for (const run of titleRuns(source.title)) {
         expect(
           run.length,
           `"${run}" in "${plainTitle(source.title)}" cannot break`,
-        ).toBeLessThanOrEqual(MOBILE_CARD_CHARS);
+        ).toBeLessThanOrEqual(WIDEST_FITTING_TITLE_RUN);
       }
     }
   });
@@ -84,7 +98,15 @@ describe("the landing page does not advertise a removed feature (#175)", () => {
     expect(landingPage()).not.toMatch(/trend data/i);
   });
 
-  it("does not promise editorial transcripts", () => {
+  /**
+   * Scoped to the phrase, and it should not be read as more than that. The
+   * Editorial Intelligence feature card still says "editorial expertise and
+   * transcripts", which no phrase match can catch and which #175 did not ask
+   * to change — it names three things to change and this is not one. If
+   * editorial really is Phase 2 material, that card is a separate ticket, and
+   * this test is not the thing standing between it and a visitor.
+   */
+  it("does not promise editorial transcripts by that name", () => {
     expect(landingPage()).not.toMatch(/editorial transcripts/i);
   });
 

--- a/frontend/lib/landingContent.ts
+++ b/frontend/lib/landingContent.ts
@@ -1,0 +1,61 @@
+/**
+ * The data sources the marketing landing page advertises.
+ *
+ * These live here rather than inline in the page (#175) because the list is a
+ * claim about the product, not a layout detail: the heading counts the cards,
+ * and every card has to name something a visitor will actually get. Editorial
+ * transcripts (deferred to Phase 2) and Google Trends (removed, #176) were
+ * both advertised here after they stopped being true. As data in `lib/`, the
+ * claim can be tested; as JSX it could only be grepped.
+ */
+export type DataSource = {
+  title: string;
+  description: string;
+};
+
+/**
+ * A soft hyphen: invisible until the browser needs to break the word, at which
+ * point it renders as a hyphen at that point.
+ *
+ * The card grid stays two-up at every width, so on a phone a card offers about
+ * 98px of text — narrower than "Recommendations" set in 18px Montserrat (179px)
+ * at any font size the heading could plausibly take. The word has to break
+ * somewhere. `hyphens: auto` does not do it (Chrome leaves the word overflowing
+ * its card), and `overflow-wrap: break-word` alone breaks mid-syllable with no
+ * hyphen — "Recomme / ndations". Marking the syllables is the one option that
+ * breaks where a typesetter would, and it costs nothing at desktop width, where
+ * the character is never rendered.
+ */
+const SHY = "­";
+
+/** Strips the soft hyphens back out — a title's real text, for tests. */
+export const plainTitle = (title: string) => title.replaceAll(SHY, "");
+
+/**
+ * The heading over the cards. It states a count, so it is only true for as
+ * long as `DATA_SOURCES` has four entries — the pair is asserted together.
+ */
+export const DATA_SOURCES_HEADING = "Four data sources.";
+
+export const DATA_SOURCES: DataSource[] = [
+  {
+    title: "Brand Research",
+    description:
+      "Automated web research into advertiser positioning, campaigns, and competitors.",
+  },
+  {
+    title: "Audience Segments & Reach",
+    description:
+      "The most relevant targetable segments per platform, each with real reach.",
+  },
+  {
+    title: `Format Recom${SHY}men${SHY}da${SHY}tions`,
+    description:
+      "Ad format benchmarks matched to the brief, naming specific products over generic advice.",
+  },
+  {
+    title: "Campaign History & Historical Research",
+    description:
+      "Delivery data from the advertiser's past campaigns and comparable brands, plus matched research studies.",
+  },
+];

--- a/frontend/lib/landingContent.ts
+++ b/frontend/lib/landingContent.ts
@@ -8,10 +8,10 @@
  * both advertised here after they stopped being true. As data in `lib/`, the
  * claim can be tested; as JSX it could only be grepped.
  */
-export type DataSource = {
+export interface DataSource {
   title: string;
   description: string;
-};
+}
 
 /**
  * A soft hyphen: invisible until the browser needs to break the word, at which
@@ -30,6 +30,15 @@ const SHY = "­";
 
 /** Strips the soft hyphens back out — a title's real text, for tests. */
 export const plainTitle = (title: string) => title.replaceAll(SHY, "");
+
+/**
+ * The pieces a title can break into: the runs between its spaces and its soft
+ * hyphens. Lives here beside `SHY` rather than in the test, so the one rule for
+ * where a title may break is stated once — the character is invisible, and a
+ * second copy of it in a regex is a copy no reviewer can see.
+ */
+export const titleRuns = (title: string) =>
+  title.split(new RegExp(`[\\s${SHY}]+`)).filter(Boolean);
 
 /**
  * The heading over the cards. It states a count, so it is only true for as


### PR DESCRIPTION
Closes #175.

The marketing landing page advertised four data sources, two of which a visitor will not get: editorial transcripts are deferred to Phase 2, and Google Trends was removed from the product by #176. It also claimed the four combine into "one unified strategy", and a feature card promised "real-time Google Trends signals".

## What changed

**The claim.** "Four data sources. *One unified strategy.*" becomes "Four data sources." Nothing replaces the dropped clause.

**The cards.** Editorial Transcripts and Google Trends are replaced by Format Recommendations and Campaign History & Historical Research — both things the product ships today. Brand Research and Audience Segments & Reach are untouched, so the count stays at four and the heading stays truthful.

**The third mention.** "Audience & Trends" becomes "Audience Behaviour", keeping the half of the card that was true. The supporting paragraph under the heading also changed: it listed "editorial expertise ... and live trend data" as the four sources, so leaving it would have defeated the point of the ticket.

## Two things worth a reviewer's attention

**The cards moved into `frontend/lib/landingContent.ts`.** The list is a claim about the product rather than a layout detail: the heading counts the cards, and every card has to name something a visitor actually gets. As data in `lib/` the claim can be tested; as JSX it could only be grepped. The heading moved with it, because it states a count that is only true while the list has four entries — the pair is asserted together. This follows the same reasoning `briefExport.ts` records for lifting rules out of JSX.

**Mobile needed more than copy.** The grid is two-up at every width, so on a 390px phone a card holds about 98px of text, and "Recommendations" measures 179px in the tile's own 18px Montserrat — it does not fit at any font size the heading could plausibly take. Measured in a real browser: `hyphens: auto` does not break it (Chrome leaves the word overflowing its card, `scrollWidth` 179 against `clientWidth` 98), and `overflow-wrap: break-word` alone breaks mid-syllable with no hyphen, rendering "Recomme / ndations" on a marketing page. So the titles carry soft hyphens — invisible at desktop width, a proper hyphen where the word has to break.

The test capping every unbreakable run at ten characters is deliberately **a heuristic, not a measurement**, and says so: a character count in a proportional face is the glyph-width estimate `tests/test_tile_fit.py` exists to reject. There is no font-metrics harness on this side of the repo and four marketing titles do not justify adding one. It catches the regression it was written for — a title arriving with no break opportunity — and nothing more.

## Verification

- `npm run build`, `npm run typecheck`, 140 frontend tests, 658 backend tests — all pass
- Rendered against `next build && next start` (not `next dev`) at 1440px and 390px: grid two-up at both, no card overflows, no horizontal page overflow, and no visible hyphen at desktop width

## Known gap, deliberately left

The Editorial Intelligence feature card still says "editorial expertise and **transcripts**", and the bottom CTA still says "editorial insight". #175 names three things to change and neither is one of them, and no phrase match on "editorial transcripts" can catch the split-word form — so the pin test now states which form it matches rather than reading as though it guards the whole page. Followed up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)