### PR TITLE
Stop advertising editorial on the landing page (#181)

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -1168,3 +1168,34 @@ version of the check.
 capacity, and whether a string fits is a question about a specific string in a
 specific box. Measure it; do not delegate it to a CSS property that degrades
 silently.
+
+---
+
+## 7 Aug 2026 — A phrase-scoped test on a page-level claim reads as a guard and isn't (#175, #181)
+
+**What happened:** #175 required that "no occurrence of 'Google Trends',
+'editorial transcripts' or 'unified strategy' remains anywhere on the landing
+page", and the pin test matched exactly those phrases. It passed while the page
+still said "editorial expertise and transcripts" in a feature card, "deep
+editorial expertise" in the hero, and "editorial insight" in the closing CTA —
+three wordings of the claim the ticket was written to remove, none of them the
+phrase.
+
+**Why the test looked fine:** it was derived from the acceptance criterion
+verbatim, and the criterion named phrases. Both were really about a promise,
+and a promise has more than one wording. The gap only surfaced because a
+reviewer read the page rather than the assertion.
+
+**The fix (#181):** match the word, not the phrase — `not.toMatch(/editorial/i)`
+over the one file that makes the promise. Scope came from choosing the file,
+not from narrowing the pattern: "editorial" is legitimate everywhere else in
+this product (the brief's Editorial Insights section, the transcripts pipeline
+in `src/`), so a repo-wide match would have been unusable and a phrase match was
+unenforceable. One file, one broad pattern is the combination that works.
+
+**Transferable point:** when a requirement is "X is not claimed anywhere",
+a test enumerating today's wordings of X pins today's copy, not the
+requirement. Ask what the narrowest _scope_ is that lets the broadest
+_pattern_ hold — and if no broad pattern can hold, the test is documentation,
+so say so in it, as [[hyphens-auto-is-not-a-wrapping-strategy]] does about its
+character cap.

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -36,7 +36,7 @@ export default function LandingPage() {
             <p className="text-xl md:text-2xl text-slate-400 max-w-2xl font-light leading-relaxed mb-12">
               The 1st party planning tool that draws on our extensive
               behavioural data, in house research, advertiser understanding and
-              deep editorial expertise for{" "}
+              proven campaign history for{" "}
               <span className="text-accent-cyan font-medium">
                 tailored recommendations
               </span>{" "}
@@ -83,7 +83,7 @@ export default function LandingPage() {
             Planning.
           </SectionHeading>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            {/* Editorial Intelligence */}
+            {/* Campaign History */}
             <div className="group bg-surface-container-lowest p-10 rounded-2xl border border-white/5 hover:border-accent-cyan/20 transition-all duration-500 relative overflow-hidden">
               <div className="mb-8 inline-flex p-4 rounded-xl bg-accent-cyan/10 text-accent-cyan group-hover:bg-accent-cyan group-hover:text-white transition-colors relative z-10">
                 <svg
@@ -96,16 +96,17 @@ export default function LandingPage() {
                     strokeLinecap="round"
                     strokeLinejoin="round"
                     strokeWidth={1.5}
-                    d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+                    d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"
                   />
                 </svg>
               </div>
               <h3 className="font-headline text-2xl font-bold mb-4 relative z-10">
-                Editorial Intelligence
+                Campaign History
               </h3>
               <p className="text-slate-400 leading-relaxed relative z-10">
-                Draws on in-house editorial expertise and transcripts to surface
-                the themes and angles that resonate with your audience.
+                Real delivery data from the advertiser&apos;s past campaigns and
+                comparable brands, so a recommendation starts from what has
+                already worked.
               </p>
             </div>
 
@@ -213,7 +214,7 @@ export default function LandingPage() {
             Build your Prism Plan
           </h2>
           <p className="text-xl text-slate-400 mb-12 max-w-2xl mx-auto">
-            Turn editorial insight, audience data, and brand research into
+            Turn campaign history, audience data, and brand research into
             actionable strategy in seconds.
           </p>
           <Link href="/app" onClick={() => trackCta("Get Started")}>

--- a/frontend/lib/landingContent.test.ts
+++ b/frontend/lib/landingContent.test.ts
@@ -99,15 +99,21 @@ describe("the landing page does not advertise a removed feature (#175)", () => {
   });
 
   /**
-   * Scoped to the phrase, and it should not be read as more than that. The
-   * Editorial Intelligence feature card still says "editorial expertise and
-   * transcripts", which no phrase match can catch and which #175 did not ask
-   * to change — it names three things to change and this is not one. If
-   * editorial really is Phase 2 material, that card is a separate ticket, and
-   * this test is not the thing standing between it and a visitor.
+   * Not scoped to a phrase, deliberately (#181). This started as a match on
+   * "editorial transcripts", which passed while the page still promised
+   * "editorial expertise and transcripts" in a feature card, "deep editorial
+   * expertise" in the hero and "editorial insight" in the closing CTA — three
+   * wordings of the one claim, none of them that phrase. A page-level promise
+   * needs a page-level guard, so this matches the word: editorial is Phase 2,
+   * and until it ships the marketing page may not offer it in any wording.
+   *
+   * The word is legitimate elsewhere in the product — the brief's Editorial
+   * Insights section, the transcripts pipeline in `src/` — and this test reads
+   * one file for that reason.
    */
-  it("does not promise editorial transcripts by that name", () => {
-    expect(landingPage()).not.toMatch(/editorial transcripts/i);
+  it("does not promise editorial, in any wording", () => {
+    expect(landingPage()).not.toMatch(/editorial/i);
+    expect(landingPage()).not.toMatch(/transcripts?/i);
   });
 
   it("drops the unified strategy claim", () => {


### PR DESCRIPTION
Closes #181. **Stacked on #180** — base is `fix/175-homepage-data-sources`, same file. GitHub will retarget this to `main` when #180 merges.

#175 removed the Editorial Transcripts data-source card because editorial is deferred to Phase 2, then left three other wordings of the same promise standing.

## What changed

| Where | Was | Now |
|---|---|---|
| Hero subtitle | "deep editorial expertise" | "proven campaign history" |
| Feature card | "Editorial Intelligence" — "in-house editorial expertise and transcripts" | "Campaign History" — real delivery data from past campaigns and comparable brands |
| Closing CTA | "Turn editorial insight, audience data, and brand research…" | "Turn campaign history, audience data, and brand research…" |

**The hero was not in the ticket.** I wrote #181 from the review of #175 and named two mentions; the hero's "deep editorial expertise" turned up while implementing it. It is the most prominent of the three — the h1 subtitle — so leaving it would have defeated the ticket. I noted this on the issue rather than shipping work the ticket does not describe.

**The feature card is replaced, not deleted.** Its row is three-up on desktop and a two-card row reads as breakage. The ticket left this open as a judgement call; Campaign History fills the slot with something the product ships. The icon changes with it — the open book belonged to transcripts, and a clock reads as history without colliding with the bar chart on the Audience card.

## The test change is the substance

The pin test moves from a phrase to the word:

```diff
-  it("does not promise editorial transcripts by that name", () => {
-    expect(landingPage()).not.toMatch(/editorial transcripts/i);
+  it("does not promise editorial, in any wording", () => {
+    expect(landingPage()).not.toMatch(/editorial/i);
+    expect(landingPage()).not.toMatch(/transcripts?/i);
```

Matching the phrase is precisely what let three wordings of one claim through #175 — the test passed on a page that promised editorial in three places. A page-level promise needs a page-level guard.

Scope comes from reading **one file**, not from narrowing the pattern. "editorial" is legitimate elsewhere in this product — the brief's Editorial Insights section, the transcripts pipeline in `src/` — so a repo-wide match would be unusable and a phrase match is unenforceable. One file, one broad pattern is the combination that holds. `LESSONS_LEARNED.md` records this.

## Verification

- `npm run build`, `npm run typecheck`, 140 frontend tests, 658 backend tests — all pass
- Rendered against `next build && next start` at 1440px and 390px: feature row three-up on desktop and stacked on mobile, no card overflows, no horizontal page overflow, and no wording of editorial on the rendered page

## Note

This changes what the page claims, not what the product does. The transcripts pipeline, ChromaDB ingest and the brief's Editorial Insights section are all untouched — when editorial ships, the copy comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)